### PR TITLE
Code Coverage

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -68,3 +68,8 @@ jobs:
         run: cargo doc --locked --all --no-deps
         env:
           RUSTDOCFLAGS: "-D rustdoc::broken-intra-doc-links -D rustdoc::private_intra_doc_links"
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
> github secret set in [IT ticket](https://www.notion.so/openzeppelin/Set-github-repo-token-CODECOV_TOKEN-for-Open-Zeppelin-polkadot-runtime-template-7999cf0499fc4746a824c5ec828a865e)

considered putting this in a separate workflow, but would rather not copying/paste most of the workflow boilerplate into a new workflow and bloat the CI config

Closes #18 