### PR TITLE
Fix CI to check build and run tests in std

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -62,7 +62,7 @@ jobs:
         run: cargo test
 
       - name: Check build
-        run: cargo build --release
+        run: cargo check --release
 
       - name: Check clippy
         run: cargo clippy --locked --all-targets -- -D warnings


### PR DESCRIPTION
Closes #28 so that CI checks runtime build & tests.

For evidence that CI did not check runtime build before this PR, see issue #38 and its associated fix