### PR TITLE
Add changelog for future releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Configured pallet-multisig (#13).
-- Set up Docs (#19)
+- Fork cumulus parachain template (#11)
+- Configured pallet-multisig (#13)
 - Configured pallet-proxy (#20)
 - Configured pallet-utility (#36)
 - Integration tests (#24)
+- Set up Docs (#51)
+- Docs for pallet-proxy (#57)
+- Docs for aura-ext (#59)
+- Docs for parachain-system (#63)
+- Docs for collator-selection (#63) 
+- Docs for pallet-multisig (#64)
 - Docs for pallet-transaction-payment (#53)
-- Docs for pallet-message-queue (#66)
+- Docs for pallet-message-queue (#58)
 - Docs for weights & fees (#66)
+- Docs for xcmp-queue (#73)
+- Docs for balances (#72)
+- Docs for xcm-executor (#77)
+- Docs for pallet-xcm (#76)
 
 ### Fixed
 
 - Fix runtime build (#40)
 - Add pallet index to multisig (#45)
-- Fix CI to ensure runtime builds (#46)
+- Update LICENSE (#50)
+- Fix CI to verify runtime builds (#46)
 - Don't run Rust CI on Doc Changes (#54)
-- Improve multisig docs (#67)


### PR DESCRIPTION
Adds a Changelog according to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) for tracking changes between releases.

Closes #30 

Follow up #70 is to automate releases iff the changelog changes.