### PR TITLE
Fix runtime: add pallet-multisig to std

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -101,6 +101,7 @@ std = [
 	"pallet-authorship/std",
 	"pallet-balances/std",
 	"pallet-collator-selection/std",
+	"pallet-multisig/std",
 	"pallet-proxy/std",
 	"pallet-session/std",
 	"pallet-sudo/std",


### PR DESCRIPTION
pallet-multisig was not added to the `std` list for the runtime `Cargo.toml`.

Not sure why the CI did not catch this, but it was preventing runtime compilation in #94 and another PR in progress. I extracted the fix into this PR in case there is confusion reviewing those PRs.

Here was the compilation error:
```rust, ignore
(amar-update-deps-3-to-5)⚡ % cargo build                                                                         
   Compiling pallet-timestamp v4.0.0-dev (https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.5.0#789ffb66)
...
error: cannot find macro `vec` in this scope
   --> /Users/4meta5/.cargo/git/checkouts/polkadot-sdk-cff69157b985ed76/789ffb6/substrate/frame/multisig/src/lib.rs:618:5
    |
618 |                 vec![who.clone()].try_into().map_err(|_| Error::<T>::TooManySignatories)?;
    |                 ^^^
    |
help: consider importing one of these items
    |
51  + use codec::alloc::vec;
    |
51  + use scale_info::prelude::vec;
    |
51  + use sp_std::vec;
    |

error: could not compile `pallet-multisig` (lib) due to previous error
warning: build failed, waiting for other jobs to finish...
^Z  Building [======================> ] 996/1016: parachain-template-runtime(build)  
```

## OS

MacOS