### PR TITLE
fixed "missing host function" bug

### DIFF
--- a/evm-template/node/src/service.rs
+++ b/evm-template/node/src/service.rs
@@ -45,8 +45,19 @@ use crate::eth::{
 /// Native executor type.
 pub struct ParachainNativeExecutor;
 
+#[cfg(not(feature = "runtime-benchmarks"))]
+type HostFunctions =
+    (sp_io::SubstrateHostFunctions, cumulus_client_service::storage_proof_size::HostFunctions);
+
+#[cfg(feature = "runtime-benchmarks")]
+type HostFunctions = (
+    sp_io::SubstrateHostFunctions,
+    cumulus_client_service::storage_proof_size::HostFunctions,
+    frame_benchmarking::benchmarking::HostFunctions,
+);
+
 impl sc_executor::NativeExecutionDispatch for ParachainNativeExecutor {
-    type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
+    type ExtendHostFunctions = HostFunctions;
 
     fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
         parachain_template_runtime::apis::api::dispatch(method, data)

--- a/evm-template/node/src/service.rs
+++ b/evm-template/node/src/service.rs
@@ -53,18 +53,6 @@ type HostFunctions = (
     frame_benchmarking::benchmarking::HostFunctions,
 );
 
-// impl sc_executor::NativeExecutionDispatch for ParachainNativeExecutor {
-//     type ExtendHostFunctions = HostFunctions;
-
-//     fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
-//         parachain_template_runtime::apis::api::dispatch(method, data)
-//     }
-
-//     fn native_version() -> sc_executor::NativeVersion {
-//         parachain_template_runtime::native_version()
-//     }
-// }
-
 type ParachainExecutor = WasmExecutor<HostFunctions>;
 
 type ParachainClient = TFullClient<Block, RuntimeApi, ParachainExecutor>;

--- a/evm-template/node/src/service.rs
+++ b/evm-template/node/src/service.rs
@@ -27,7 +27,7 @@ use parachain_template_runtime::{
 };
 use sc_client_api::Backend;
 use sc_consensus::ImportQueue;
-use sc_executor::NativeElseWasmExecutor;
+use sc_executor::WasmExecutor;
 use sc_network::NetworkBlock;
 use sc_network_sync::SyncingService;
 use sc_service::{Configuration, PartialComponents, TFullBackend, TFullClient, TaskManager};
@@ -42,9 +42,6 @@ use crate::eth::{
     FrontierBackend, FrontierPartialComponents,
 };
 
-/// Native executor type.
-pub struct ParachainNativeExecutor;
-
 #[cfg(not(feature = "runtime-benchmarks"))]
 type HostFunctions =
     (sp_io::SubstrateHostFunctions, cumulus_client_service::storage_proof_size::HostFunctions);
@@ -56,19 +53,19 @@ type HostFunctions = (
     frame_benchmarking::benchmarking::HostFunctions,
 );
 
-impl sc_executor::NativeExecutionDispatch for ParachainNativeExecutor {
-    type ExtendHostFunctions = HostFunctions;
+// impl sc_executor::NativeExecutionDispatch for ParachainNativeExecutor {
+//     type ExtendHostFunctions = HostFunctions;
 
-    fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
-        parachain_template_runtime::apis::api::dispatch(method, data)
-    }
+//     fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
+//         parachain_template_runtime::apis::api::dispatch(method, data)
+//     }
 
-    fn native_version() -> sc_executor::NativeVersion {
-        parachain_template_runtime::native_version()
-    }
-}
+//     fn native_version() -> sc_executor::NativeVersion {
+//         parachain_template_runtime::native_version()
+//     }
+// }
 
-type ParachainExecutor = NativeElseWasmExecutor<ParachainNativeExecutor>;
+type ParachainExecutor = WasmExecutor<HostFunctions>;
 
 type ParachainClient = TFullClient<Block, RuntimeApi, ParachainExecutor>;
 
@@ -111,7 +108,7 @@ pub fn new_partial(
         })
         .transpose()?;
 
-    let executor = sc_service::new_native_or_wasm_executor(config);
+    let executor = sc_service::new_wasm_executor(config);
 
     let (client, backend, keystore_container, task_manager) =
         sc_service::new_full_parts_record_import::<Block, RuntimeApi, _>(


### PR DESCRIPTION
There is a bug that Santiago mentioned and I also observed an issue during the generation of wasm or node launch:
```
Error: Service(Client(VersionInvalid("Other error happened while constructing the runtime: runtime requires function imports which are not present on the host: 'env:ext_storage_proof_size_storage_proof_size_version_1'")))
2024-06-11 09:25:43 [Parachain] Cannot create a runtime error=Other("runtime requires function imports which are not present on the host: 'env:ext_storage_proof_size_storage_proof_size_version_1'")
```
