### PR TITLE
Port the trivial audit fixes to evm

### DIFF
--- a/evm-template/runtime/src/apis.rs
+++ b/evm-template/runtime/src/apis.rs
@@ -172,34 +172,41 @@ impl_runtime_apis! {
     }
 
     impl fp_rpc::EthereumRuntimeRPCApi<Block> for Runtime {
+        /// Returns runtime defined pallet_evm::ChainId.
         fn chain_id() -> u64 {
             <Runtime as pallet_evm::Config>::ChainId::get()
         }
 
+        /// Returns pallet_evm::Accounts by address.
         fn account_basic(address: H160) -> EVMAccount {
             let (account, _) = pallet_evm::Pallet::<Runtime>::account_basic(&address);
             account
         }
 
+        /// Returns FixedGasPrice::min_gas_price
         fn gas_price() -> U256 {
             let (gas_price, _) = <Runtime as pallet_evm::Config>::FeeCalculator::min_gas_price();
             gas_price
         }
 
+        /// For a given account address, returns pallet_evm::AccountCodes.
         fn account_code_at(address: H160) -> Vec<u8> {
             pallet_evm::AccountCodes::<Runtime>::get(address)
         }
 
+        /// Returns the converted FindAuthor::find_author authority id.
         fn author() -> H160 {
             <pallet_evm::Pallet<Runtime>>::find_author()
         }
 
+        /// For a given account address and index, returns pallet_evm::AccountStorages.
         fn storage_at(address: H160, index: U256) -> H256 {
             let mut tmp = [0u8; 32];
             index.to_big_endian(&mut tmp);
             pallet_evm::AccountStorages::<Runtime>::get(address, H256::from_slice(&tmp[..]))
         }
 
+        /// Returns a frame_ethereum::call response.
         fn call(
             from: H160,
             to: H160,
@@ -253,6 +260,7 @@ impl_runtime_apis! {
             ).map_err(|err| err.error.into())
         }
 
+        /// Returns a frame_ethereum::create response.
         fn create(
             from: H160,
             data: Vec<u8>,
@@ -303,18 +311,22 @@ impl_runtime_apis! {
             ).map_err(|err| err.error.into())
         }
 
+        /// Return the current transaction status.
         fn current_transaction_statuses() -> Option<Vec<TransactionStatus>> {
             pallet_ethereum::CurrentTransactionStatuses::<Runtime>::get()
         }
 
+        /// Return the current block.
         fn current_block() -> Option<pallet_ethereum::Block> {
             pallet_ethereum::CurrentBlock::<Runtime>::get()
         }
 
+        /// Return the current receipt.
         fn current_receipts() -> Option<Vec<pallet_ethereum::Receipt>> {
             pallet_ethereum::CurrentReceipts::<Runtime>::get()
         }
 
+        /// Return all the current data for a block in a single runtime call.
         fn current_all() -> (
             Option<pallet_ethereum::Block>,
             Option<Vec<pallet_ethereum::Receipt>>,
@@ -327,6 +339,7 @@ impl_runtime_apis! {
             )
         }
 
+        /// Receives a `Vec<OpaqueExtrinsic>` and filters all the ethereum transactions.
         fn extrinsic_filter(
             xts: Vec<<Block as BlockT>::Extrinsic>,
         ) -> Vec<EthereumTransaction> {
@@ -336,12 +349,16 @@ impl_runtime_apis! {
             }).collect::<Vec<EthereumTransaction>>()
         }
 
+        /// Return the elasticity multiplier.
         fn elasticity() -> Option<Permill> {
             Some(pallet_base_fee::Elasticity::<Runtime>::get())
         }
 
+        /// Used to determine if gas limit multiplier for non-transactional calls (eth_call/estimateGas)
+        /// is supported.
         fn gas_limit_multiplier_support() {}
 
+        /// Return the pending block.
         fn pending_block(
             xts: Vec<<Block as BlockT>::Extrinsic>,
         ) -> (Option<pallet_ethereum::Block>, Option<Vec<TransactionStatus>>) {
@@ -359,6 +376,7 @@ impl_runtime_apis! {
     }
 
     impl fp_rpc::ConvertTransactionRuntimeApi<Block> for Runtime {
+        /// Converts an ethereum transaction into a transaction suitable for the runtime.
         fn convert_transaction(transaction: EthereumTransaction) -> <Block as BlockT>::Extrinsic {
             UncheckedExtrinsic::new_unsigned(
                 pallet_ethereum::Call::<Runtime>::transact { transaction }.into(),

--- a/evm-template/runtime/src/apis.rs
+++ b/evm-template/runtime/src/apis.rs
@@ -339,7 +339,7 @@ impl_runtime_apis! {
             )
         }
 
-        /// Receives a `Vec<OpaqueExtrinsic>` and filters all the ethereum transactions.
+        /// Receives a `Vec<OpaqueExtrinsic>` and filters out all the non-ethereum transactions.
         fn extrinsic_filter(
             xts: Vec<<Block as BlockT>::Extrinsic>,
         ) -> Vec<EthereumTransaction> {

--- a/evm-template/runtime/src/apis.rs
+++ b/evm-template/runtime/src/apis.rs
@@ -321,7 +321,7 @@ impl_runtime_apis! {
             pallet_ethereum::CurrentBlock::<Runtime>::get()
         }
 
-        /// Return the current receipt.
+        /// Return the current receipts.
         fn current_receipts() -> Option<Vec<pallet_ethereum::Receipt>> {
             pallet_ethereum::CurrentReceipts::<Runtime>::get()
         }

--- a/evm-template/runtime/src/configs/mod.rs
+++ b/evm-template/runtime/src/configs/mod.rs
@@ -30,7 +30,6 @@ use parachains_common::message_queue::{NarrowOriginToSibling, ParaIdToSibling};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use polkadot_runtime_common::{
     impls::{LocatableAssetConverter, VersionedLocatableAsset, VersionedLocationConverter},
-    xcm_sender::NoPriceForMessageDelivery,
     BlockHashCount, SlowAdjustingFeeUpdate,
 };
 use scale_info::TypeInfo;
@@ -44,24 +43,28 @@ use sp_std::marker::PhantomData;
 use sp_version::RuntimeVersion;
 // XCM Imports
 use xcm::{
-    latest::{prelude::BodyId, InteriorLocation, Junction::PalletInstance},
+    latest::{
+        prelude::{AssetId, BodyId},
+        InteriorLocation,
+        Junction::PalletInstance,
+    },
     VersionedLocation,
 };
 use xcm_builder::PayOverXcm;
 #[cfg(not(feature = "runtime-benchmarks"))]
 use xcm_builder::ProcessXcmMessage;
-use xcm_config::XcmOriginToTransactDispatchOrigin;
+use xcm_config::{RelayLocation, XcmOriginToTransactDispatchOrigin};
 
 use crate::{
     constants::{
-        currency::{deposit, EXISTENTIAL_DEPOSIT, MICROCENTS},
+        currency::{deposit, CENTS, EXISTENTIAL_DEPOSIT, MICROCENTS},
         AVERAGE_ON_INITIALIZE_RATIO, DAYS, HOURS, MAXIMUM_BLOCK_WEIGHT, MAX_BLOCK_LENGTH,
         MAX_POV_SIZE, NORMAL_DISPATCH_RATIO, SLOT_DURATION, VERSION, WEIGHT_PER_GAS,
     },
     opaque,
     types::{
         AccountId, Balance, Block, BlockNumber, CollatorSelectionUpdateOrigin, ConsensusHook, Hash,
-        Nonce,
+        Nonce, PriceForSiblingParachainDelivery,
     },
     weights::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight},
     Aura, Balances, BaseFee, CollatorSelection, EVMChainId, MessageQueue, OpenZeppelinPrecompiles,
@@ -97,6 +100,7 @@ parameter_types! {
         })
         .avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
         .build_or_panic();
+        // generic substrate prefix. For more info, see: [Polkadot Accounts In-Depth](https://wiki.polkadot.network/docs/learn-account-advanced#:~:text=The%20address%20format%20used%20in,belonging%20to%20a%20specific%20network)
     pub const SS58Prefix: u16 = 42;
 }
 
@@ -105,10 +109,12 @@ impl Contains<RuntimeCall> for NormalFilter {
     fn contains(c: &RuntimeCall) -> bool {
         match c {
             // We filter anonymous proxy as they make "reserve" inconsistent
-            // See: https://github.com/paritytech/substrate/blob/37cca710eed3dadd4ed5364c7686608f5175cce1/frame/proxy/src/lib.rs#L270
+            // See: https://github.com/paritytech/polkadot-sdk/blob/v1.9.0-rc2/substrate/frame/proxy/src/lib.rs#L260
             RuntimeCall::Proxy(method) => !matches!(
                 method,
-                pallet_proxy::Call::create_pure { .. } | pallet_proxy::Call::kill_pure { .. }
+                pallet_proxy::Call::create_pure { .. }
+                    | pallet_proxy::Call::kill_pure { .. }
+                    | pallet_proxy::Call::remove_proxies { .. }
             ),
             _ => true,
         }
@@ -164,12 +170,11 @@ impl frame_system::Config for Runtime {
 parameter_types! {
     pub MaximumSchedulerWeight: frame_support::weights::Weight = Perbill::from_percent(80) *
         RuntimeBlockWeights::get().max_block;
-    pub const MaxScheduledPerBlock: u32 = 50;
-    pub const NoPreimagePostponement: Option<u32> = Some(10);
+    pub const MaxScheduledRuntimeCallsPerBlock: u32 = 50;
 }
 
 impl pallet_scheduler::Config for Runtime {
-    type MaxScheduledPerBlock = MaxScheduledPerBlock;
+    type MaxScheduledPerBlock = MaxScheduledRuntimeCallsPerBlock;
     type MaximumWeight = MaximumSchedulerWeight;
     type OriginPrivilegeCmp = frame_support::traits::EqualPrivilegeOnly;
     type PalletsOrigin = OriginCaller;
@@ -393,6 +398,10 @@ impl cumulus_pallet_aura_ext::Config for Runtime {}
 
 parameter_types! {
     pub const MaxInboundSuspended: u32 = 1000;
+    /// The asset ID for the asset that we use to pay for message delivery fees.
+    pub FeeAssetId: AssetId = AssetId(RelayLocation::get());
+    /// The base fee for the message delivery fees. Kusama is based for the reference.
+    pub const ToSiblingBaseDeliveryFee: u128 = CENTS.saturating_mul(3);
 }
 
 impl cumulus_pallet_xcmp_queue::Config for Runtime {
@@ -400,7 +409,7 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
     type ControllerOrigin = EnsureRoot<AccountId>;
     type ControllerOriginConverter = XcmOriginToTransactDispatchOrigin;
     type MaxInboundSuspended = MaxInboundSuspended;
-    type PriceForSiblingDelivery = NoPriceForMessageDelivery<ParaId>;
+    type PriceForSiblingDelivery = PriceForSiblingParachainDelivery;
     type RuntimeEvent = RuntimeEvent;
     type VersionWrapper = ();
     type WeightInfo = cumulus_pallet_xcmp_queue::weights::SubstrateWeight<Runtime>;
@@ -427,6 +436,10 @@ impl pallet_multisig::Config for Runtime {
 }
 
 parameter_types! {
+    // pallet_session ends the session after a fixed period of blocks.
+    // The first session will have length of Offset,
+    // and the following sessions will have length of Period.
+    // This may prove nonsensical if Offset >= Period.
     pub const Period: u32 = 6 * HOURS;
     pub const Offset: u32 = 0;
 }
@@ -473,9 +486,6 @@ parameter_types! {
     pub const SessionLength: BlockNumber = 6 * HOURS;
     // StakingAdmin pluralistic body.
     pub const StakingAdminBodyId: BodyId = BodyId::Defense;
-}
-
-parameter_types! {
     pub const MaxCandidates: u32 = 100;
     pub const MaxInvulnerables: u32 = 20;
     pub const MinEligibleCollators: u32 = 4;
@@ -516,9 +526,6 @@ parameter_types! {
     // pallet instance (which sits at index 13).
     pub TreasuryInteriorLocation: InteriorLocation = PalletInstance(13).into();
     pub const MaxApprovals: u32 = 100;
-}
-
-parameter_types! {
     pub TreasuryAccount: AccountId = Treasury::account_id();
 }
 

--- a/evm-template/runtime/src/configs/mod.rs
+++ b/evm-template/runtime/src/configs/mod.rs
@@ -59,7 +59,7 @@ use crate::{
     constants::{
         currency::{deposit, CENTS, EXISTENTIAL_DEPOSIT, MICROCENTS},
         AVERAGE_ON_INITIALIZE_RATIO, DAYS, HOURS, MAXIMUM_BLOCK_WEIGHT, MAX_BLOCK_LENGTH,
-        MAX_POV_SIZE, NORMAL_DISPATCH_RATIO, SLOT_DURATION, VERSION, WEIGHT_PER_GAS,
+        NORMAL_DISPATCH_RATIO, SLOT_DURATION, VERSION, WEIGHT_PER_GAS,
     },
     opaque,
     types::{
@@ -578,7 +578,7 @@ impl pallet_ethereum::Config for Runtime {
 
 parameter_types! {
     pub BlockGasLimit: U256 = U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
-    pub GasLimitPovSizeRatio: u64 = BlockGasLimit::get().as_u64().saturating_div(MAX_POV_SIZE);
+    pub GasLimitPovSizeRatio: u64 = BlockGasLimit::get().as_u64().saturating_div(cumulus_primitives_core::relay_chain::MAX_POV_SIZE as u64);
     pub PrecompilesValue: OpenZeppelinPrecompiles<Runtime> = OpenZeppelinPrecompiles::<_>::new();
     pub WeightPerGas: Weight = Weight::from_parts(WEIGHT_PER_GAS, 0);
     pub SuicideQuickClearLimit: u32 = 0;

--- a/evm-template/runtime/src/constants.rs
+++ b/evm-template/runtime/src/constants.rs
@@ -48,7 +48,7 @@ pub const MILLISECS_PER_BLOCK: u64 = 6000;
 pub const MILLISECS_PER_BLOCK: u64 = 12000;
 
 // NOTE: Currently it is not possible to change the slot duration after the
-// chain has started.       Attempting to do so will brick block production.
+// chain has started. Attempting to do so will brick block production.
 pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
 
 // Time is measured by number of blocks.
@@ -89,6 +89,7 @@ pub const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32 = 6000;
 /// Maximum length for a block.
 pub const MAX_BLOCK_LENGTH: u32 = 5 * 1024 * 1024;
 
+/// The maximum legal size of a POV block, in bytes.
 pub const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
 
 /// Current approximation of the gas/s consumption considering

--- a/evm-template/runtime/src/constants.rs
+++ b/evm-template/runtime/src/constants.rs
@@ -89,9 +89,6 @@ pub const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32 = 6000;
 /// Maximum length for a block.
 pub const MAX_BLOCK_LENGTH: u32 = 5 * 1024 * 1024;
 
-/// The maximum legal size of a POV block, in bytes.
-pub const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
-
 /// Current approximation of the gas/s consumption considering
 /// EVM execution over compiled WASM (on 4.4Ghz CPU).
 /// Given the 500ms Weight, from which 75% only are used for transactions,

--- a/evm-template/runtime/src/types.rs
+++ b/evm-template/runtime/src/types.rs
@@ -12,11 +12,14 @@ use xcm_executor::traits::JustTry;
 use xcm_primitives::AsAssetType;
 
 pub use crate::{
-    configs::{xcm_config::RelayLocation, AssetType, StakingAdminBodyId, TreasuryAccount},
+    configs::{
+        xcm_config::RelayLocation, AssetType, FeeAssetId, StakingAdminBodyId,
+        ToSiblingBaseDeliveryFee, TransactionByteFee, TreasuryAccount,
+    },
     constants::{
         BLOCK_PROCESSING_VELOCITY, RELAY_CHAIN_SLOT_DURATION_MILLIS, UNINCLUDED_SEGMENT_CAPACITY,
     },
-    AllPalletsWithSystem, Runtime, RuntimeCall,
+    AllPalletsWithSystem, Runtime, RuntimeCall, XcmpQueue,
 };
 use crate::{AssetManager, Assets};
 
@@ -74,6 +77,14 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
+>;
+
+/// Price For Sibling Parachain Delivery
+pub type PriceForSiblingParachainDelivery = polkadot_runtime_common::xcm_sender::ExponentialPrice<
+    FeeAssetId,
+    ToSiblingBaseDeliveryFee,
+    TransactionByteFee,
+    XcmpQueue,
 >;
 
 /// Configures the number of blocks that can be created without submission of validity proof to the relay chain

--- a/generic-template/runtime/src/types.rs
+++ b/generic-template/runtime/src/types.rs
@@ -73,6 +73,7 @@ pub type Executive = frame_executive::Executive<
     AllPalletsWithSystem,
 >;
 
+/// Price For Sibling Parachain Delivery
 pub type PriceForSiblingParachainDelivery = polkadot_runtime_common::xcm_sender::ExponentialPrice<
     FeeAssetId,
     ToSiblingBaseDeliveryFee,


### PR DESCRIPTION
This PR ports the trivial audit fixes for generic template to evm template. Partially addresses #237 

Below is the recap of the audit findings and the related issues & PRs:

- [ ]  3.2.1 XCM delivery fees (no issue is submitted at that time due to visibility) → https://github.com/OpenZeppelin/polkadot-runtime-templates/pull/159/files
    - [ ]  tracking in #223 
- [x]  3.2.2 no xcm delivery fees #154→ https://github.com/OpenZeppelin/polkadot-runtime-templates/pull/156
- [ ]  3.2.3 incorrect weights for xcm and message queue #135 → https://github.com/OpenZeppelin/polkadot-runtime-templates/pull/153
- [ ]  3.2.4 insufficient benchmarking #138 → https://github.com/OpenZeppelin/polkadot-runtime-templates/pull/149

- [x]  4.1 filtering #141 → https://github.com/OpenZeppelin/polkadot-runtime-templates/pull/146
- [ ]  4.2 benchmarking #142
- [x]  4.3 improve docs for runtime parameters #143 → https://github.com/OpenZeppelin/polkadot-runtime-templates/pull/167
    - [x]  also documented new stuff in `impl fp_rpc::EthereumRuntimeRPCApi<Block> for Runtime`
    - [x] removed `const MAX_POV_SIZE` declaration, since it is available to import from polkadot-sdk
- [x]  4.4 remove link to archived repo #144 → https://github.com/OpenZeppelin/polkadot-runtime-templates/pull/146

---

Except 3.2.1 (`FeeManager`), all the remaining ones are related to Weights/Benchmarking, and I think they will be solved once #235  is completed. Please correct me if I'm wrong @KitHat.

