### PR TITLE
Add sccache and use nextest in our workflow

### DIFF
--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -55,20 +55,6 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v4
 
-      - name: Cache cargo registry & git sources
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/
-            ~/.cargo/git/db/
-          # More specific key first(higher cache hit)
-          key: ${{ runner.os }}-cargo-evm-template-${{ hashFiles('**/Cargo.lock') }}
-          # Less specific keys after(lower cache hit)
-          restore-keys: |
-            ${{ runner.os }}-cargo-generic-template-${{ hashFiles('**/Cargo.lock') }}
-            ${{ runner.os }}-cargo-
-
       - name: Run sccache
         uses: mozilla-actions/sccache-action@v0.0.4
 
@@ -79,27 +65,37 @@ jobs:
 
       - name: install rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy
 
       - name: Install toml-sort
         run: cargo install --git https://github.com/4meta5/toml_sort
+
       - name: Add file permissions for toml-sort
         run: chmod +x ./scripts/toml-sort.sh
+
       - name: Add file permissions for check-toml-sorted
         run: chmod +x ./scripts/check-toml-sorted.sh
+
       - name: Check Cargo.toml files are formatted using toml_sort
         run: ./scripts/check-toml-sorted.sh
 
       - name: Check format
         run: cargo fmt --all -- --check
 
+      - name: "Install nextest"
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
       - name: Run tests
-        run: cargo test --release
+        run: cargo nextest run --release
 
       - name: Check benchmarking compilation
         run: cargo check --release --features runtime-benchmarks
 
       - name: Run tests with async backing
-        run: cargo test --release --features="async-backing"
+        run: cargo nextest run --release --features="async-backing"
 
       - name: Check clippy
         run: cargo clippy --release --locked --all-targets -- -D warnings
@@ -109,6 +105,7 @@ jobs:
         env:
           RUSTDOCFLAGS: "-D rustdoc::broken-intra-doc-links -D rustdoc::private_intra_doc_links"
 
+      # FIXME: Calculate coverage and define how to upload all template coverage reports
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         env:

--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -67,7 +67,7 @@ jobs:
       - name: install rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          components: clippy
+          components: clippy, rustfmt
 
       - name: Install toml-sort
         run: cargo install --git https://github.com/4meta5/toml_sort

--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -29,6 +29,9 @@ env:
   WASM_BUILD_CLEAN_TARGET: 1
   # stripping symbols and optimizing for binary size
   RUSTFLAGS: -C strip=symbols -C opt-level=s
+  # Enable sscache
+  RUSTC_WRAPPER: "sccache"
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   evm-clippy-fmt-test:
@@ -51,6 +54,23 @@ jobs:
     steps:
       - name: git checkout
         uses: actions/checkout@v4
+
+      - name: Cache cargo registry & git sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/
+            ~/.cargo/git/db/
+          # More specific key first(higher cache hit)
+          key: ${{ runner.os }}-cargo-evm-template-${{ hashFiles('**/Cargo.lock') }}
+          # Less specific keys after(lower cache hit)
+          restore-keys: |
+            ${{ runner.os }}-cargo-generic-template-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-cargo-
+
+      - name: Run sccache
+        uses: mozilla-actions/sccache-action@v0.0.4
 
       - name: Install Protoc
         uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0

--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -32,7 +32,7 @@ env:
   # Enable sscache
   RUSTC_WRAPPER: "sccache"
   SCCACHE_GHA_ENABLED: "true"
-  SCCACHE_CACHE_SIZE: "100GB"
+  SCCACHE_CACHE_SIZE: "50GB"
 
 jobs:
   evm-clippy-fmt-test:

--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -32,6 +32,7 @@ env:
   # Enable sscache
   RUSTC_WRAPPER: "sccache"
   SCCACHE_GHA_ENABLED: "true"
+  SCCACHE_CACHE_SIZE: "100GB"
 
 jobs:
   evm-clippy-fmt-test:

--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -67,7 +67,7 @@ jobs:
       - name: install rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          components: clippy
+          components: clippy, rustfmt
 
       - name: Install toml-sort
         run: cargo install --git https://github.com/4meta5/toml_sort

--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -32,6 +32,7 @@ env:
   # Enable sscache
   RUSTC_WRAPPER: "sccache"
   SCCACHE_GHA_ENABLED: "true"
+  SCCACHE_CACHE_SIZE: "100GB"
 
 jobs:
   clippy-fmt-test:

--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -29,6 +29,9 @@ env:
   WASM_BUILD_CLEAN_TARGET: 1
   # stripping symbols and optimizing for binary size
   RUSTFLAGS: -C strip=symbols -C opt-level=s
+  # Enable sscache
+  RUSTC_WRAPPER: "sccache"
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   clippy-fmt-test:
@@ -52,6 +55,23 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v4
 
+      - name: Cache cargo registry & git sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/
+            ~/.cargo/git/db/
+          # More specific key first(higher cache hit)
+          key: ${{ runner.os }}-cargo-generic-template-${{ hashFiles('**/Cargo.lock') }}
+          # Less specific keys after(lower cache hit)
+          restore-keys: |
+            ${{ runner.os }}-cargo-evm-template-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-cargo-
+
+      - name: Run sccache
+        uses: mozilla-actions/sccache-action@v0.0.4
+
       - name: Install Protoc
         uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
         with:
@@ -62,10 +82,13 @@ jobs:
 
       - name: Install toml-sort
         run: cargo install --git https://github.com/4meta5/toml_sort
+
       - name: Add file permissions for toml-sort
         run: chmod +x ./scripts/toml-sort.sh
+
       - name: Add file permissions for check-toml-sorted
         run: chmod +x ./scripts/check-toml-sorted.sh
+
       - name: Check Cargo.toml files are formatted using toml_sort
         run: ./scripts/check-toml-sorted.sh
 

--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -55,20 +55,6 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v4
 
-      - name: Cache cargo registry & git sources
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/
-            ~/.cargo/git/db/
-          # More specific key first(higher cache hit)
-          key: ${{ runner.os }}-cargo-generic-template-${{ hashFiles('**/Cargo.lock') }}
-          # Less specific keys after(lower cache hit)
-          restore-keys: |
-            ${{ runner.os }}-cargo-evm-template-${{ hashFiles('**/Cargo.lock') }}
-            ${{ runner.os }}-cargo-
-
       - name: Run sccache
         uses: mozilla-actions/sccache-action@v0.0.4
 
@@ -79,6 +65,8 @@ jobs:
 
       - name: install rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy
 
       - name: Install toml-sort
         run: cargo install --git https://github.com/4meta5/toml_sort
@@ -92,17 +80,22 @@ jobs:
       - name: Check Cargo.toml files are formatted using toml_sort
         run: ./scripts/check-toml-sorted.sh
 
+      - name: "Install nextest"
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
       - name: Check format
         run: cargo fmt --all -- --check
 
       - name: Run tests
-        run: cargo test --release
+        run: cargo nextest run --release
 
       - name: Check benchmarking compilation
         run: cargo check --release --features runtime-benchmarks
 
       - name: Run tests with async backing
-        run: cargo test --release --features="async-backing"
+        run: cargo nextest run --release --features="async-backing"
 
       - name: Check clippy
         run: cargo clippy --release --locked --all-targets -- -D warnings
@@ -112,6 +105,7 @@ jobs:
         env:
           RUSTDOCFLAGS: "-D rustdoc::broken-intra-doc-links -D rustdoc::private_intra_doc_links"
 
+      # FIXME: Calculate coverage and define how to upload all template coverage reports
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         env:

--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -32,7 +32,7 @@ env:
   # Enable sscache
   RUSTC_WRAPPER: "sccache"
   SCCACHE_GHA_ENABLED: "true"
-  SCCACHE_CACHE_SIZE: "100GB"
+  SCCACHE_CACHE_SIZE: "50GB"
 
 jobs:
   clippy-fmt-test:


### PR DESCRIPTION
Fixes #259

Our workflows take about 50min each on every PR(on main it is longer given we also run it on mac OS). This can be improved using [sccache](https://github.com/mozilla/sccache/) which avoids compilation when possible. It is common in polkadot projects to have this given long build times.
**With this, subsequent runs take around 35min.** 
- Add sccache step
- Use [nextest](https://github.com/nextest-rs/nextest) for tests, which is up to 3x faster than cargo test, and also shows the results in a much nicer format. It also shows you if you have some slow tests. Currently this is not a big advantage, since our tests are quick, but even the formatting is worth it I think.
