### PR TITLE
Allow dependabod to automatically open PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+  - package-ecosystem: cargo
+    directory: '/'
+    # Handle updates for crates from https://github.com/paritytech/polkadot-sdk manually.
+    ignore:
+      - dependency-name: 'sc-*'
+      - dependency-name: 'sp-*'
+      - dependency-name: 'frame-*'
+      - dependency-name: 'pallet-*'
+      - dependency-name: 'substrate-*'
+      - dependency-name: 'polkadot-*'
+      - dependency-name: 'cumulus-*'
+      - dependency-name: 'assets-*'
+      - dependency-name: 'xcm-*'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
Fixes #278 

This allows dependabot to open PRs for both vulnerable dependencies and just regular dependency updates. For polkadot sdk we ingore it and continue with manual updates(idea borrowed from [Frontier](https://github.com/polkadot-evm/frontier/blob/master/.github/dependabot.yml)) since we want to retain control for when and how to update these.
