### PR TITLE
Remove security warning for EVM template and fix broken link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 Along with the templates, OpenZeppelin also provides a [documentation website](https://docs.openzeppelin.com/substrate-runtimes) that explains the templates and the details.
 
-
 ## About this repository and templates
 
 This repository contains all of our templates. Each template has its own sub-directory, is completely standalone, and can be used independently.
@@ -12,26 +11,28 @@ This repository contains all of our templates. Each template has its own sub-dir
 For example: if you want to use our `generic runtime template`, you can just copy that subdirectory, and it will work on its own. You don't need anything from other templates nor from the root directory of this repository for your selected template to work.
 
 ---
+
 > [!WARNING]
 > Avoid using `main` for production deployments and use release branches instead. `main` is a development branch that should be avoided in favor of tagged releases. The release process involves security measures that the `main` branch does not guarantee.
+
 ### Generic Runtime Template
 
 This template has all the basic features you expect to find on a typical L1 blockchain or parachain. Basic, yet preserving the most important pallets that are used in the Polkadot ecosystem today and a safe runtime base configuration.
-You can find a full list of the pallets included in this template in our [docs](https://docs.openzeppelin.com/substrate-runtimes/1.0.0/)
-
+You can find a full list of the pallets included in this template in our [docs](https://docs.openzeppelin.com/substrate-runtimes/runtimes/generic)
 
 ### EVM template
 
-> [!WARNING]
-> EVM template is still under development.
+This template uses [frontier](https://github.com/polkadot-evm/frontier) pallets and has EVM compatibility out of the box. You can migrate your solidity contracts or EVM compatible dapps easily to your parachain using this template. Here are some of the key features included:
 
-This template has evm compatibility out of the box. You can migrate your solidity contracts or evm compatible dapps easily to your blockchain using this template.
+- 20 byte addresses: Existing tooling works out of the box, no more awkward conversion, this template handles that for you.
+- Account Abstraction support: The Entrypoint contract is included as part of the pre-deployed contracts that will be in the genesis block.
+- Extensible pre-deployed contracts: In addition to the entrypoint, you can add your own smart contract to be included in the genesis block.
 
+For a step by step guide on how to deploy this to your own local environment using Zombienet check this [tutorial](https://docs.openzeppelin.com/substrate-runtimes/guides/testing_with_zombienet)
 
 ### How to use
 
-Please refer to our docs for a `quick start` [guide](https://docs.openzeppelin.com/substrate-runtimes/).
-
+Please refer to our docs for a `quick start` [guide](https://docs.openzeppelin.com/substrate-runtimes/guides/quick_start).
 
 ## Security
 
@@ -42,13 +43,3 @@ Refer to [SECURITY.md](SECURITY.md) for more details.
 ## License
 
 OpenZeppelin Runtime Templates are released under the [GNU v3 License](LICENSE).
-
-
-
-
-
-
-
-
-
-

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -6,7 +6,7 @@
 A collection of runtimes that describe parachains with different purposes.
 
 === Runtimes
-* xref:guides/runtimes/generic.adoc[Generic Runtime Template]
+* xref:runtimes/generic.adoc[Generic Runtime Template]
 * xref:runtimes/evm.adoc[EVM Runtime Template]
 
 


### PR DESCRIPTION
### Readme
- Remove security warning for EVM template now that we have published the audit and released.
- Add some details about the benefits of the EVM template.
- Fix some links

### Docs
- Fix a link that was broken in the home page for the Generic Template