### PR TITLE
fix: rename templates binaries in the zombienet files

### DIFF
--- a/evm-template/zombienet-config/devnet.toml
+++ b/evm-template/zombienet-config/devnet.toml
@@ -15,6 +15,7 @@ id = 1000
 addToGenesis = true
 cumulus_based = true
 chain = "dev"
+force_decorator = "generic-evm"
 
 [[parachains.collators]]
 name = "collator01"

--- a/evm-template/zombienet-config/devnet.toml
+++ b/evm-template/zombienet-config/devnet.toml
@@ -2,13 +2,13 @@
 chain = "rococo-local"
 default_command = "./bin-v1.6.0/polkadot"
 
-	[[relaychain.nodes]]
-	name = "alice"
-	validator = true
+[[relaychain.nodes]]
+name = "alice"
+validator = true
 
-	[[relaychain.nodes]]
-	name = "bob"
-	validator = true
+[[relaychain.nodes]]
+name = "bob"
+validator = true
 
 [[parachains]]
 id = 1000
@@ -16,16 +16,16 @@ addToGenesis = true
 cumulus_based = true
 chain = "dev"
 
-	[[parachains.collators]]
-	name = "collator01"
-	command = "./target/release/parachain-template-node"
-	ws_port = 9933
-	rpc_port = 8833
-	args = ["--rpc-max-connections 10000"]
+[[parachains.collators]]
+name = "collator01"
+command = "./target/release/evm-template-node"
+ws_port = 9933
+rpc_port = 8833
+args = ["--rpc-max-connections 10000"]
 
-	[[parachains.collators]]
-	name = "collator02"
-	ws_port = 9822
-	rpc_port = 8822
-	command = "./target/release/parachain-template-node"
-	args = ["--rpc-max-connections 10000"]
+[[parachains.collators]]
+name = "collator02"
+ws_port = 9822
+rpc_port = 8822
+command = "./target/release/evm-template-node"
+args = ["--rpc-max-connections 10000"]

--- a/generic-template/zombienet-config/devnet.toml
+++ b/generic-template/zombienet-config/devnet.toml
@@ -18,7 +18,7 @@ chain = "dev"
 
 [[parachains.collators]]
 name = "collator01"
-command = "./target/release/parachain-template-node"
+command = "./target/release/generic-template-node"
 ws_port = 9933
 rpc_port = 8833
 args = ["--rpc-max-connections 10000"]
@@ -27,5 +27,5 @@ args = ["--rpc-max-connections 10000"]
 name = "collator02"
 ws_port = 9822
 rpc_port = 8822
-command = "./target/release/parachain-template-node"
+command = "./target/release/generic-template-node"
 args = ["--rpc-max-connections 10000"]


### PR DESCRIPTION
This PR adds `force_decorator = "generic-evm"` in the `devnet.toml` of the EVM parachain as suggested in https://github.com/paritytech/zombienet/issues/1826. Closes https://github.com/OpenZeppelin/polkadot-runtime-templates/issues/289

This PR also renames the parachain binaries in the Zombienet files of the `generic-template` and `evm-template` to enhance the UX. With this change users don't have to to manually rename the binaries.

