### PR TITLE
Add needs triage issue label for new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug report
 description: Create a report to help us improve
 title: "🐞 [Bug]: "
-labels: ["bug"]
+labels: ["bug", "needs triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/core_implementation.yml
+++ b/.github/ISSUE_TEMPLATE/core_implementation.yml
@@ -1,7 +1,7 @@
 name: 🏗️ Core Implementation
 description: Create a report to help us improve
 title: "🏗️ [Core Feature]: "
-labels: ["core"]
+labels: ["core", "needs triage"]
 body:
   - type: checkboxes
     id: templates

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: 🎁 Feature Request
 description: Suggest an idea for this project ⚡️
 title: "🎁 [Feature Request]: "
-labels: ["enhancement"]
+labels: ["enhancement", "needs triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
When a new issue is added we don't have a clear process/way to determine if it is valid, what works is needed, etc. By adding this label at least we can filter out and see what issues are new and someone from our team can assign the proper labels and decide if it is valid.