### PR TITLE
#305 Fixing unexpectedly high weights for XCM pallet

### DIFF
--- a/evm-template/runtime/src/apis.rs
+++ b/evm-template/runtime/src/apis.rs
@@ -478,6 +478,7 @@ impl_runtime_apis! {
                 ).into());
                 /// The base fee for the message delivery fees. Kusama is based for the reference.
                 pub const ToParentBaseDeliveryFee: u128 = CENTS.saturating_mul(3);
+                pub const InitialTransferAssetAmount: u128 = 4001070000100;
             }
             pub type PriceForParentDelivery = polkadot_runtime_common::xcm_sender::ExponentialPrice<
                 FeeAssetId,
@@ -523,7 +524,7 @@ impl_runtime_apis! {
                         RawOrigin::Signed(manager_id.clone()).into(),
                         local_asset_id.into(),
                         sp_runtime::MultiAddress::Id(who),
-                        3001010000000,
+                        InitialTransferAssetAmount::get(),
                     );
                     AssetManager::set_asset_type_asset_id(asset_type.clone(), local_asset_id.into());
 
@@ -533,7 +534,7 @@ impl_runtime_apis! {
                     );
 
                     // set up transfer asset
-                    let initial_asset_amount: u128 = 4001070000100;
+                    let initial_asset_amount: u128 = InitialTransferAssetAmount::get();
                     let (asset_id, _, _) = pallet_assets::benchmarking::create_default_minted_asset::<
                         Runtime,
                         ()

--- a/evm-template/runtime/src/apis.rs
+++ b/evm-template/runtime/src/apis.rs
@@ -506,7 +506,7 @@ impl_runtime_apis! {
                     use xcm_primitives::AssetTypeGetter;
                     use frame_system::RawOrigin;
 
-                    // set up fee asset 
+                    // set up fee asset
                     let fee_location = RelayLocation::get();
                     let who: AccountId = frame_benchmarking::whitelisted_caller();
 
@@ -566,7 +566,7 @@ impl_runtime_apis! {
                 ) -> Option<(AssetList, u32, Location, Box<dyn FnOnce()>)> {
                     use xcm_primitives::AssetTypeGetter;
                     // set up local asset
-                    let initial_asset_amount: u128 = 1000000011;                    
+                    let initial_asset_amount: u128 = 1000000011;
 
                     let (asset_id, _, _) = pallet_assets::benchmarking::create_default_minted_asset::<
                         Runtime,
@@ -600,7 +600,7 @@ impl_runtime_apis! {
                     let fee_index: u32 = 0;
 
                     let who = frame_benchmarking::whitelisted_caller();
-                    
+
                     let verify: Box<dyn FnOnce()> = Box::new(move || {
                         // verify balance after transfer, decreased by
                         // transferred amount (and delivery fees)

--- a/evm-template/runtime/src/apis.rs
+++ b/evm-template/runtime/src/apis.rs
@@ -1,6 +1,6 @@
 use frame_support::{
     genesis_builder_helper::{build_state, get_preset},
-    traits::{OnFinalize, PalletInfoAccess},
+    traits::OnFinalize,
     weights::Weight,
 };
 use pallet_ethereum::{
@@ -503,6 +503,7 @@ impl_runtime_apis! {
                 }
 
                 fn reserve_transferable_asset_and_dest() -> Option<(Asset, Location)> {
+                    use frame_system::traits::PalletInfoAccess;
                     use xcm_primitives::AssetTypeGetter;
                     use frame_system::RawOrigin;
 
@@ -564,6 +565,7 @@ impl_runtime_apis! {
 
                 fn set_up_complex_asset_transfer(
                 ) -> Option<(AssetList, u32, Location, Box<dyn FnOnce()>)> {
+                    use frame_system::traits::PalletInfoAccess;
                     use xcm_primitives::AssetTypeGetter;
                     // set up local asset
                     let initial_asset_amount: u128 = 1000000011;

--- a/evm-template/runtime/src/apis.rs
+++ b/evm-template/runtime/src/apis.rs
@@ -503,7 +503,7 @@ impl_runtime_apis! {
                 }
 
                 fn reserve_transferable_asset_and_dest() -> Option<(Asset, Location)> {
-                    use frame_system::traits::PalletInfoAccess;
+                    use frame_support::traits::PalletInfoAccess;
                     use xcm_primitives::AssetTypeGetter;
                     use frame_system::RawOrigin;
 
@@ -565,7 +565,7 @@ impl_runtime_apis! {
 
                 fn set_up_complex_asset_transfer(
                 ) -> Option<(AssetList, u32, Location, Box<dyn FnOnce()>)> {
-                    use frame_system::traits::PalletInfoAccess;
+                    use frame_support::traits::PalletInfoAccess;
                     use xcm_primitives::AssetTypeGetter;
                     // set up local asset
                     let initial_asset_amount: u128 = 1000000011;

--- a/evm-template/runtime/src/configs/xcm_config.rs
+++ b/evm-template/runtime/src/configs/xcm_config.rs
@@ -301,7 +301,6 @@ impl pallet_xcm::Config for Runtime {
     type XcmExecuteFilter = Everything;
     #[cfg(not(feature = "runtime-benchmarks"))]
     type XcmExecuteFilter = Nothing;
-    // ^ Disable dispatchable execute on the XCM pallet.
     // Needs to be `Everything` for local testing.
     type XcmExecutor = XcmExecutor<XcmConfig>;
     type XcmReserveTransferFilter = Everything;

--- a/evm-template/runtime/src/configs/xcm_config.rs
+++ b/evm-template/runtime/src/configs/xcm_config.rs
@@ -297,9 +297,9 @@ impl pallet_xcm::Config for Runtime {
     type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
     /// Rerun benchmarks if you are making changes to runtime configuration.
     type WeightInfo = weights::pallet_xcm::WeightInfo<Runtime>;
-    #[cfg(feature="runtime-benchmarks")]
+    #[cfg(feature = "runtime-benchmarks")]
     type XcmExecuteFilter = Everything;
-    #[cfg(not(feature="runtime-benchmarks"))]
+    #[cfg(not(feature = "runtime-benchmarks"))]
     type XcmExecuteFilter = Nothing;
     // ^ Disable dispatchable execute on the XCM pallet.
     // Needs to be `Everything` for local testing.

--- a/evm-template/runtime/src/configs/xcm_config.rs
+++ b/evm-template/runtime/src/configs/xcm_config.rs
@@ -297,11 +297,14 @@ impl pallet_xcm::Config for Runtime {
     type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
     /// Rerun benchmarks if you are making changes to runtime configuration.
     type WeightInfo = weights::pallet_xcm::WeightInfo<Runtime>;
+    #[cfg(feature="runtime-benchmarks")]
+    type XcmExecuteFilter = Everything;
+    #[cfg(not(feature="runtime-benchmarks"))]
     type XcmExecuteFilter = Nothing;
     // ^ Disable dispatchable execute on the XCM pallet.
     // Needs to be `Everything` for local testing.
     type XcmExecutor = XcmExecutor<XcmConfig>;
-    type XcmReserveTransferFilter = Nothing;
+    type XcmReserveTransferFilter = Everything;
     type XcmRouter = XcmRouter;
     type XcmTeleportFilter = Nothing;
 

--- a/generic-template/runtime/src/apis.rs
+++ b/generic-template/runtime/src/apis.rs
@@ -1,5 +1,7 @@
 use frame_support::{
-    genesis_builder_helper::{build_state, get_preset}, traits::PalletInfoAccess, weights::Weight
+    genesis_builder_helper::{build_state, get_preset},
+    traits::PalletInfoAccess,
+    weights::Weight,
 };
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -17,7 +19,10 @@ use crate::Aura;
 #[cfg(feature = "async-backing")]
 use crate::{constants::SLOT_DURATION, types::ConsensusHook};
 use crate::{
-    constants::VERSION, types::{AccountId, Balance, Block, Executive, Nonce}, InherentDataExt, ParachainSystem, Runtime, RuntimeCall, RuntimeGenesisConfig, SessionKeys, System, TransactionPayment
+    constants::VERSION,
+    types::{AccountId, Balance, Block, Executive, Nonce},
+    InherentDataExt, ParachainSystem, Runtime, RuntimeCall, RuntimeGenesisConfig, SessionKeys,
+    System, TransactionPayment,
 };
 
 impl_runtime_apis! {

--- a/generic-template/runtime/src/apis.rs
+++ b/generic-template/runtime/src/apis.rs
@@ -1,6 +1,5 @@
 use frame_support::{
     genesis_builder_helper::{build_state, get_preset},
-    traits::PalletInfoAccess,
     weights::Weight,
 };
 use sp_api::impl_runtime_apis;
@@ -279,7 +278,7 @@ impl_runtime_apis! {
                 }
 
                 fn reserve_transferable_asset_and_dest() -> Option<(Asset, Location)> {
-
+                    use frame_system::traits::PalletInfoAccess;
                     ParachainSystem::open_outbound_hrmp_channel_for_benchmarks_or_tests(
                         RandomParaId::get().into()
                     );
@@ -310,6 +309,7 @@ impl_runtime_apis! {
 
                 fn set_up_complex_asset_transfer(
                 ) -> Option<(AssetList, u32, Location, Box<dyn FnOnce()>)> {
+                    use frame_system::traits::PalletInfoAccess;
                     // set up local asset
                     let asset_amount: u128 = 10u128;
                     let initial_asset_amount: u128 = 1000000011;
@@ -354,6 +354,7 @@ impl_runtime_apis! {
                 }
 
                 fn get_asset() -> Asset {
+                    use frame_system::traits::PalletInfoAccess;
                     Asset {
                         id: AssetId((Location {parents: 0, interior: (PalletInstance(<Assets as PalletInfoAccess>::index() as u8), GeneralIndex(1)).into()}).into()),
                         fun: Fungible(ExistentialDeposit::get()),

--- a/generic-template/runtime/src/apis.rs
+++ b/generic-template/runtime/src/apis.rs
@@ -278,7 +278,7 @@ impl_runtime_apis! {
                 }
 
                 fn reserve_transferable_asset_and_dest() -> Option<(Asset, Location)> {
-                    use frame_system::traits::PalletInfoAccess;
+                    use frame_support::traits::PalletInfoAccess;
                     ParachainSystem::open_outbound_hrmp_channel_for_benchmarks_or_tests(
                         RandomParaId::get().into()
                     );
@@ -309,7 +309,7 @@ impl_runtime_apis! {
 
                 fn set_up_complex_asset_transfer(
                 ) -> Option<(AssetList, u32, Location, Box<dyn FnOnce()>)> {
-                    use frame_system::traits::PalletInfoAccess;
+                    use frame_support::traits::PalletInfoAccess;
                     // set up local asset
                     let asset_amount: u128 = 10u128;
                     let initial_asset_amount: u128 = 1000000011;
@@ -354,7 +354,7 @@ impl_runtime_apis! {
                 }
 
                 fn get_asset() -> Asset {
-                    use frame_system::traits::PalletInfoAccess;
+                    use frame_support::traits::PalletInfoAccess;
                     Asset {
                         id: AssetId((Location {parents: 0, interior: (PalletInstance(<Assets as PalletInfoAccess>::index() as u8), GeneralIndex(1)).into()}).into()),
                         fun: Fungible(ExistentialDeposit::get()),

--- a/generic-template/runtime/src/apis.rs
+++ b/generic-template/runtime/src/apis.rs
@@ -17,10 +17,7 @@ use crate::Aura;
 #[cfg(feature = "async-backing")]
 use crate::{constants::SLOT_DURATION, types::ConsensusHook};
 use crate::{
-    constants::VERSION,
-    types::{AccountId, Balance, Block, Executive, Nonce},
-    InherentDataExt, ParachainSystem, Runtime, RuntimeCall, RuntimeGenesisConfig, SessionKeys,
-    System, TransactionPayment,
+    constants::VERSION, types::{AccountId, Balance, Block, Executive, Nonce}, InherentDataExt, ParachainSystem, Runtime, RuntimeCall, RuntimeGenesisConfig, SessionKeys, System, TransactionPayment
 };
 
 impl_runtime_apis! {
@@ -281,7 +278,6 @@ impl_runtime_apis! {
                     ParachainSystem::open_outbound_hrmp_channel_for_benchmarks_or_tests(
                         RandomParaId::get().into()
                     );
-                    let fee_amount: u128 = <Runtime as pallet_balances::Config>::ExistentialDeposit::get();
                     let balance = 3001070000000;
                     let who = frame_benchmarking::whitelisted_caller();
                     let _ =
@@ -298,14 +294,6 @@ impl_runtime_apis! {
                     let asset_id_u32: u32 = asset_id.into();
 
                     let location = Location {parents: 0, interior: (PalletInstance(<Assets as PalletInfoAccess>::index() as u8), GeneralIndex(asset_id_u32 as u128)).into()};
-                    let asset_id = AssetId(location.clone());
-                    let asset = Asset {
-                        id: asset_id.clone(),
-                        fun: Fungible(ExistentialDeposit::get()),
-                    };
-                    let local_asset_id: crate::types::AssetId = 1;
-                    // TODO: create account id to create asset
-                    let account_id: AccountId = [0u8;32].into();
                     Some((
                         Asset {
                             fun: Fungible(ExistentialDeposit::get()),
@@ -317,7 +305,47 @@ impl_runtime_apis! {
 
                 fn set_up_complex_asset_transfer(
                 ) -> Option<(AssetList, u32, Location, Box<dyn FnOnce()>)> {
-                    None
+                    // set up local asset
+                    let asset_amount: u128 = 10u128;
+                    let initial_asset_amount: u128 = 1000000011;
+                    let (asset_id, _, _) = pallet_assets::benchmarking::create_default_minted_asset::<
+                        Runtime,
+                        ()
+                    >(true, initial_asset_amount);
+                    let asset_id_u32: u32 = asset_id.into();
+
+                    let self_reserve = Location {
+                        parents:0,
+                        interior: [
+                            PalletInstance(<Assets as PalletInfoAccess>::index() as u8), GeneralIndex(asset_id_u32 as u128)
+                        ].into()
+                    };
+
+                    let destination: xcm::v4::Location = Parent.into();
+
+                    let fee_amount: u128 = <Runtime as pallet_balances::Config>::ExistentialDeposit::get();
+                    let fee_asset: Asset = (self_reserve.clone(), fee_amount).into();
+
+                    // Give some multiple of transferred amount
+                    let balance = fee_amount * 1000;
+                    let who = frame_benchmarking::whitelisted_caller();
+                    let _ =
+                        <Balances as frame_support::traits::Currency<_>>::make_free_balance_be(&who, balance);
+
+                    // verify initial balance
+                    assert_eq!(Balances::free_balance(&who), balance);
+                    let transfer_asset: Asset = (self_reserve.clone(), asset_amount).into();
+
+                    let assets: cumulus_primitives_core::Assets = vec![fee_asset.clone(), transfer_asset].into();
+                    let fee_index: u32 = 0;
+
+                    let verify: Box<dyn FnOnce()> = Box::new(move || {
+                        // verify balance after transfer, decreased by
+                        // transferred amount (and delivery fees)
+                        assert!(Assets::balance(asset_id_u32, &who) <= initial_asset_amount - fee_amount);
+                    });
+
+                    Some((assets, fee_index, destination, verify))
                 }
 
                 fn get_asset() -> Asset {

--- a/generic-template/runtime/src/configs/mod.rs
+++ b/generic-template/runtime/src/configs/mod.rs
@@ -323,8 +323,8 @@ impl pallet_assets::Config for Runtime {
     type ApprovalDeposit = ApprovalDeposit;
     type AssetAccountDeposit = AssetAccountDeposit;
     type AssetDeposit = AssetDeposit;
-    type AssetId = u32;
-    type AssetIdParameter = parity_scale_codec::Compact<u32>;
+    type AssetId = crate::types::AssetId;
+    type AssetIdParameter = parity_scale_codec::Compact<crate::types::AssetId>;
     type Balance = Balance;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = ();

--- a/generic-template/runtime/src/configs/xcm_config.rs
+++ b/generic-template/runtime/src/configs/xcm_config.rs
@@ -227,7 +227,6 @@ impl pallet_xcm::Config for Runtime {
     type XcmExecuteFilter = Everything;
     #[cfg(not(feature = "runtime-benchmarks"))]
     type XcmExecuteFilter = Nothing;
-    // ^ Disable dispatchable execute on the XCM pallet.
     // Needs to be `Everything` for local testing.
     type XcmExecutor = XcmExecutor<XcmConfig>;
     type XcmReserveTransferFilter = Everything;

--- a/generic-template/runtime/src/configs/xcm_config.rs
+++ b/generic-template/runtime/src/configs/xcm_config.rs
@@ -223,11 +223,14 @@ impl pallet_xcm::Config for Runtime {
     type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
     /// Rerun benchmarks if you are making changes to runtime configuration.
     type WeightInfo = weights::pallet_xcm::WeightInfo<Runtime>;
+    #[cfg(feature="runtime-benchmarks")]
+    type XcmExecuteFilter = Everything;
+    #[cfg(not(feature="runtime-benchmarks"))]
     type XcmExecuteFilter = Nothing;
     // ^ Disable dispatchable execute on the XCM pallet.
     // Needs to be `Everything` for local testing.
     type XcmExecutor = XcmExecutor<XcmConfig>;
-    type XcmReserveTransferFilter = Nothing;
+    type XcmReserveTransferFilter = Everything;
     type XcmRouter = XcmRouter;
     type XcmTeleportFilter = Nothing;
 

--- a/generic-template/runtime/src/configs/xcm_config.rs
+++ b/generic-template/runtime/src/configs/xcm_config.rs
@@ -223,9 +223,9 @@ impl pallet_xcm::Config for Runtime {
     type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
     /// Rerun benchmarks if you are making changes to runtime configuration.
     type WeightInfo = weights::pallet_xcm::WeightInfo<Runtime>;
-    #[cfg(feature="runtime-benchmarks")]
+    #[cfg(feature = "runtime-benchmarks")]
     type XcmExecuteFilter = Everything;
-    #[cfg(not(feature="runtime-benchmarks"))]
+    #[cfg(not(feature = "runtime-benchmarks"))]
     type XcmExecuteFilter = Nothing;
     // ^ Disable dispatchable execute on the XCM pallet.
     // Needs to be `Everything` for local testing.

--- a/generic-template/runtime/src/types.rs
+++ b/generic-template/runtime/src/types.rs
@@ -39,6 +39,9 @@ pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::Account
 /// Balance of an account.
 pub type Balance = u128;
 
+/// Identifier of an asset
+pub type AssetId = u32;
+
 /// Index of a transaction in the chain.
 pub type Nonce = u32;
 


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->
Updated configuration and benchmarking for XCM pallet.
In relation to original issue:

Fixed benchmarks:
- `execute`
- `transfer_assets`
- `reserve_transfer_assets`

Benchmarks that were left unchanged:
- `execute_blob` -- it was removed in `stable-2407`.
- `teleport_assets` -- we are not going to allow to teleport assets over the XCM, so we will not spend time on fixing this benchmarks. If you are willing to do it, feel free to contribute.

Fixes #305  <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests
- [x] Documentation
- [x] Pallets, that require benchmarks, are added to `scripts/assets/pallets.txt` (Pallet require benchmark if it has WeightInfo config type)
