### PR TITLE
use evm compatible accounts, and fix properties for chain spec

### DIFF
--- a/evm-template/node/src/chain_spec.rs
+++ b/evm-template/node/src/chain_spec.rs
@@ -78,6 +78,7 @@ pub fn development_config(contracts_path: ContractsPath) -> ChainSpec {
     properties.insert("tokenSymbol".into(), "UNIT".into());
     properties.insert("tokenDecimals".into(), 12.into());
     properties.insert("ss58Format".into(), 42.into());
+    properties.insert("isEthereum".into(), true.into());
     // This is very important for us, it lets us track the usage of our templates, and have no downside for the node/runtime. Please do not remove :)
     properties.insert("basedOn".into(), "OpenZeppelin EVM Template".into());
 
@@ -102,25 +103,19 @@ pub fn development_config(contracts_path: ContractsPath) -> ChainSpec {
             (get_account_id_from_seed::<ecdsa::Public>("Bob"), get_collator_keys_from_seed("Bob")),
         ],
         vec![
-            get_account_id_from_seed::<ecdsa::Public>("Alice"),
-            get_account_id_from_seed::<ecdsa::Public>("Bob"),
-            get_account_id_from_seed::<ecdsa::Public>("Charlie"),
-            get_account_id_from_seed::<ecdsa::Public>("Dave"),
-            get_account_id_from_seed::<ecdsa::Public>("Eve"),
-            get_account_id_from_seed::<ecdsa::Public>("Ferdie"),
-            get_account_id_from_seed::<ecdsa::Public>("Alice//stash"),
-            get_account_id_from_seed::<ecdsa::Public>("Bob//stash"),
-            get_account_id_from_seed::<ecdsa::Public>("Charlie//stash"),
-            get_account_id_from_seed::<ecdsa::Public>("Dave//stash"),
-            get_account_id_from_seed::<ecdsa::Public>("Eve//stash"),
-            get_account_id_from_seed::<ecdsa::Public>("Ferdie//stash"),
-            AccountId::from(hex!("33c7c88f2B2Fcb83975fCDB08d2B5bf7eA29FDCE")),
-            AccountId::from(hex!("c02db867898f227416BCB6d97190126A6b04988A")),
+            // Alith, Baltathar, Charleth and Dorothy, Ethan
+            AccountId::from(hex!("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac")),
+            AccountId::from(hex!("3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0")),
+            AccountId::from(hex!("798d4Ba9baf0064Ec19eB4F0a1a45785ae9D6DFc")),
+            AccountId::from(hex!("773539d4Ac0e786233D90A233654ccEE26a613D9")),
+            AccountId::from(hex!("Ff64d3F6efE2317EE2807d223a0Bdc4c0c49dfDB")),
         ],
-        get_account_id_from_seed::<ecdsa::Public>("Alice"),
+        // Alith
+        AccountId::from(hex!("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac")),
         1000.into(),
         contracts_path,
     ))
+    .with_properties(properties)
     .build()
 }
 
@@ -130,6 +125,7 @@ pub fn local_testnet_config(contracts_path: ContractsPath) -> ChainSpec {
     properties.insert("tokenSymbol".into(), "UNIT".into());
     properties.insert("tokenDecimals".into(), 12.into());
     properties.insert("ss58Format".into(), 42.into());
+    properties.insert("isEthereum".into(), true.into());
 
     #[allow(deprecated)]
     ChainSpec::builder(
@@ -153,20 +149,15 @@ pub fn local_testnet_config(contracts_path: ContractsPath) -> ChainSpec {
             (get_account_id_from_seed::<ecdsa::Public>("Bob"), get_collator_keys_from_seed("Bob")),
         ],
         vec![
-            get_account_id_from_seed::<ecdsa::Public>("Alice"),
-            get_account_id_from_seed::<ecdsa::Public>("Bob"),
-            get_account_id_from_seed::<ecdsa::Public>("Charlie"),
-            get_account_id_from_seed::<ecdsa::Public>("Dave"),
-            get_account_id_from_seed::<ecdsa::Public>("Eve"),
-            get_account_id_from_seed::<ecdsa::Public>("Ferdie"),
-            get_account_id_from_seed::<ecdsa::Public>("Alice//stash"),
-            get_account_id_from_seed::<ecdsa::Public>("Bob//stash"),
-            get_account_id_from_seed::<ecdsa::Public>("Charlie//stash"),
-            get_account_id_from_seed::<ecdsa::Public>("Dave//stash"),
-            get_account_id_from_seed::<ecdsa::Public>("Eve//stash"),
-            get_account_id_from_seed::<ecdsa::Public>("Ferdie//stash"),
+            // Alith, Baltathar, Charleth and Dorothy, Ethan
+            AccountId::from(hex!("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac")),
+            AccountId::from(hex!("3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0")),
+            AccountId::from(hex!("798d4Ba9baf0064Ec19eB4F0a1a45785ae9D6DFc")),
+            AccountId::from(hex!("773539d4Ac0e786233D90A233654ccEE26a613D9")),
+            AccountId::from(hex!("Ff64d3F6efE2317EE2807d223a0Bdc4c0c49dfDB")),
         ],
-        get_account_id_from_seed::<ecdsa::Public>("Alice"),
+        // Alith
+        AccountId::from(hex!("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac")),
         1000.into(),
         contracts_path,
     ))


### PR DESCRIPTION
Partially addresses #319 for `v2` branch. 

Progress:
- uses `Alith, Baltathar, etc.` for the accounts
- `chainType` is not `Ethereum` instead of `Substrate` of our evm template 
    ![image](https://github.com/user-attachments/assets/a22cf57f-a4a0-4820-8376-06f34b345f10)

Remaining problem:
- when navigated into `Accounts` in polkadot js, we still have incompatible account types:
  ![image](https://github.com/user-attachments/assets/0fec4e91-fc20-4801-aa4a-0603f8354c9e)


Notes:
- didn't change collator accounts to their `eth` variant, due to preserve the ease of running a node with `--alice` command. Turns out `--alice` is not an alias for `--name alice --validator`, but it also sets the respective key for the node with `--node-key <ALICE'S KEY>`. If I'm to change the collators to `Alith` for example, we have to:
    - figure out the key
    - explain these details in our guides
    - complicate the process a bit
- don't know why we still get the error above. However, the block production works.
- we may need a follow up PR to fix the error above, submitting this one also for sharing ideas and collaboration with R0gue team
