### PR TITLE
Change all references from rococo to paseo

### DIFF
--- a/docs/modules/ROOT/pages/guides/async_backing.adoc
+++ b/docs/modules/ROOT/pages/guides/async_backing.adoc
@@ -16,7 +16,7 @@ cargo build --release --features="async-backing"
 
 == How to test
 
-You can always test it against Rococo (it should already have enabled async backing), but the fastest way is to test against a local relay chain. In our repository you can find a script, a config and a link:https://github.com/OpenZeppelin/polkadot-runtime-templates/tree/main/generic-template/zombienet-config[manual] that will run both relay chain and a parachain. To launch a parachain with a relay chain, you will need to run these commands:
+You can always test it against Paseo (it should already have enabled async backing), but the fastest way is to test against a local relay chain. In our repository you can find a script, a config and a link:https://github.com/OpenZeppelin/polkadot-runtime-templates/tree/main/generic-template/zombienet-config[manual] that will run both relay chain and a parachain. To launch a parachain with a relay chain, you will need to run these commands:
 
 * Get the Polkadot binaries:
 ** If you are using some Linux distro, you can download the binaries:

--- a/docs/modules/ROOT/pages/guides/quick_start.adoc
+++ b/docs/modules/ROOT/pages/guides/quick_start.adoc
@@ -4,12 +4,12 @@
 
 = Quick start
 
-* Begin by visiting our link:https://github.com/OpenZeppelin/polkadot-runtime-templates[repository]. You can fork it, use it as a template, or simply clone it to your local directory.
+* Begin by visiting our link:https://github.com/OpenZeppelin/polkadot-runtime-templates[repository]. You can fork it, or simply clone it to your local directory.
 ```bash
 git clone git@github.com:OpenZeppelin/polkadot-runtime-templates.git
 ```
 
-* Move to the directory of the template you want to use. We will use the `generic runtime template` for this tutorial.
+* Move to the directory of the template you want to use. We will use the `generic runtime template` for this tutorial, but it is the same for the same applies to the xref:runtimes/evm.adoc[EVM Runtime Template].
 ```bash
 cd generic-template
 ```
@@ -19,11 +19,11 @@ cd generic-template
 cargo build --release
 ```
 
-* Receive some `ROC` from the link:https://paritytech.github.io/polkadot-testnet-faucet/[Rococo faucet]
+* Receive some `PSO` from the link:https://paritytech.github.io/polkadot-testnet-faucet/[Paseo faucet]
 
-* Reserve a ParaId on Rococo:
+* Reserve a ParaId on Paseo:
 
-** Go to link:https://polkadot.js.org/apps[PolkadotJS]. Check that it points to Rococo testnet.
+** Go to link:https://polkadot.js.org/apps[PolkadotJS]. Check that it points to Paseo testnet.
 ** Go to `Network` > `Parachains`
 ** Go to `Parathreads` tab
 ** Click the `+ ParaId` button
@@ -41,7 +41,7 @@ cargo build --release
 ** Edit the chainspec:
 
 *** Update `name`, `id` and `protocolId` to unique values.
-*** Change `relay_chain` from `rococo-local` to `rococo`.
+*** Change `relay_chain` from `paseo-local` to `paseo`.
 *** Change `para_id` and `parachainInfo.parachainId` from `1000` to the previously saved parachain id.
 
 ** Generate a raw chainspec with this command:
@@ -50,7 +50,7 @@ cargo build --release
 ./target/release/parachain-template-node build-spec --chain plain-parachain-chainspec.json --disable-default-bootnode --raw > raw-parachain-chainspec.json
 ```
 
-* Run two nodes and wait until it syncs with the Rococo relay chain. This can take a fairly long time(up to 2 days), so we can use the `fast-unsafe` flag to make the process faster since we are on a testnet(~ 3 hours). `fast` downloads the blocks without executing the transactions, and `unsafe` skips downloading the state proofs(which we are ok with since it is Rococo).
+* Run two nodes and wait until it syncs with the Paseo relay chain. This can take a fairly long time(up to 2 days), so we can use the `fast-unsafe` flag to make the process faster since we are on a testnet(~ 3 hours). `fast` downloads the blocks without executing the transactions, and `unsafe` skips downloading the state proofs(which we are ok with since it is Paseo).
 +
 ```bash
 ./target/release/parachain-template-node \
@@ -63,7 +63,7 @@ cargo build --release
     --rpc-port 8844 \
     -- \
     --execution wasm \
-    --chain <path to the Rococo chainspec> \
+    --chain <path to the Paseo chainspec> \
     --port 30343 \
     --rpc-port 9977 \
     --sync fast-unsafe
@@ -80,13 +80,13 @@ cargo build --release
     --rpc-port 8845 \
     -- \
     --execution wasm \
-    --chain <path to the Rococo chainspec> \
+    --chain <path to the Paseo chainspec> \
     --port 30343 \
     --rpc-port 9977 \
     --sync fast-unsafe
 ```
 ** `<path to datadir>` is where the downloaded chain state will be stored. It can be any folder on your computer.
-** `<path to the Rococo chainspec>` is where your Rococo chainspec is stored. You can download this file from the link:https://github.com/paritytech/polkadot-sdk/blob/release-polkadot-v1.10.0/polkadot/node/service/chain-specs/rococo.jsonofficial[official Polkadot sdk repository].
+** `<path to the Paseo chainspec>` is where your Paseo chainspec is stored. You can download this file from the link:https://github.com/paritytech/polkadot-sdk/blob/release-polkadot-v1.10.0/polkadot/node/service/chain-specs/paseo.json[official Polkadot sdk repository].
 
 * Register a parathread:
 
@@ -100,7 +100,7 @@ cargo build --release
 ```bash
 ./target/release/parachain-template-node export-genesis-wasm --chain raw-parachain-chainspec.json para-<paraId>-wasm
 ```
-** Go to link:https://polkadot.js.org/apps[PolkadotJS]. Check that it points to Rococo testnet.
+** Go to link:https://polkadot.js.org/apps[PolkadotJS]. Check that it points to Paseo testnet.
 ** Go to `Network` > `Parachains`.
 ** Go to `Parathreads` tab.
 ** Click the `+ ParaThread` button.
@@ -110,16 +110,16 @@ cargo build --release
 
 * When a parachain gets synced with a relaychain, you may start producing blocks as a parathread:
 ** Create some transaction with a PolkadotJS pointing to your parachain setup.
-** With a PolkadotJS pointing to Rococo go to `Developer` > `Extrinsics`.
+** With a PolkadotJS pointing to Paseo go to `Developer` > `Extrinsics`.
 ** Submit an extrinsic `onDemandAssignmentProvider.placeOrderAllowDeath` or `onDemandAssignmentProvider.placeOrderKeepAlive`:
-*** `maxAmount` should be not less than 10_000_000 and it is amount of 0.00001 ROC. It is an amount of ROC paid for the block.
+*** `maxAmount` should be not less than 10_000_000 and it is amount of 0.00001 PAS. It is an amount of PAS paid for the block.
 *** `paraId` should be set to your parachain id.
 *** Click `Submit` and `Sign and Submit`.
-** In some time your parathread will produce a block and in one of the next blocks of Rococo there will be an inclusion of this block
+** In some time your parathread will produce a block and in one of the next blocks of Paseo there will be an inclusion of this block
 
 == What's next?
 
 - Read our general guides to understand more about the concepts of runtime development.
 
-- Learn more about the runtime configuration. Currently, we have two runtime templates: xref:guides/runtimes/generic.adoc[Generic Runtime Template] and xref:runtimes/evm.adoc[EVM Runtime Template].
+- Learn more about the runtime configuration. Currently, we have two runtime templates: xref:runtimes/generic.adoc[Generic Runtime Template] and xref:runtimes/evm.adoc[EVM Runtime Template].
 - Explore the documentation for pallets. It may be useful if you are considering building a frontend for your parachain.

--- a/docs/modules/ROOT/pages/guides/quick_start.adoc
+++ b/docs/modules/ROOT/pages/guides/quick_start.adoc
@@ -27,15 +27,20 @@ cargo build --release
 ** Go to `Network` > `Parachains`
 ** Go to `Parathreads` tab
 ** Click the `+ ParaId` button
-** Save a `parachain id` for the further usage.
+** Save the `parachain id` for the further usage.
 ** Click `Submit` and `Sign and Submit`.
 
 * Generate and customize a chainspec:
 
+[NOTE]
+====
+We use the `generic-template-node` executable throughout all the commands since we are using the `generic-template`, but make sure to update the name of the executable if you are using any of the other runtime template.
+====
+
 ** Generate a plain chainspec with this command:
 +
 ```bash
-./target/release/parachain-template-node build-spec --disable-default-bootnode > plain-parachain-chainspec.json
+./target/release/generic-template-node build-spec --disable-default-bootnode > plain-parachain-chainspec.json
 ```
 
 ** Edit the chainspec:
@@ -47,13 +52,13 @@ cargo build --release
 ** Generate a raw chainspec with this command:
 +
 ```bash
-./target/release/parachain-template-node build-spec --chain plain-parachain-chainspec.json --disable-default-bootnode --raw > raw-parachain-chainspec.json
+./target/release/generic-template-node build-spec --chain plain-parachain-chainspec.json --disable-default-bootnode --raw > raw-parachain-chainspec.json
 ```
 
-* Run two nodes and wait until it syncs with the Paseo relay chain. This can take a fairly long time(up to 2 days), so we can use the `fast-unsafe` flag to make the process faster since we are on a testnet(~ 3 hours). `fast` downloads the blocks without executing the transactions, and `unsafe` skips downloading the state proofs(which we are ok with since it is Paseo).
+* Run two nodes and wait until it syncs with the Paseo relay chain. This can take a fairly long time(up to 2 days), so we can use the `fast-unsafe` flag to make the process faster since we are on a testnet(~ 3 hours). `fast` downloads the blocks without executing the transactions, and `unsafe` skips downloading the state proofs(which we are ok with since it is a testnet).
 +
 ```bash
-./target/release/parachain-template-node \
+./target/release/generic-template-node \
     --alice \
     --collator \
     --force-authoring \
@@ -70,7 +75,7 @@ cargo build --release
 ```
 +
 ```bash
-./target/release/parachain-template-node \
+./target/release/generic-template-node \
     --bob \
     --collator \
     --force-authoring \
@@ -93,12 +98,12 @@ cargo build --release
 ** Generate a genesis state:
 +
 ```bash
-./target/release/parachain-template-node export-genesis-state --chain raw-parachain-chainspec.json para-<paraId>-genesis-state
+./target/release/generic-template-node export-genesis-state --chain raw-parachain-chainspec.json para-<paraId>-genesis-state
 ```
 ** Generate a genesis wasm:
 +
 ```bash
-./target/release/parachain-template-node export-genesis-wasm --chain raw-parachain-chainspec.json para-<paraId>-wasm
+./target/release/generic-template-node export-genesis-wasm --chain raw-parachain-chainspec.json para-<paraId>-wasm
 ```
 ** Go to link:https://polkadot.js.org/apps[PolkadotJS]. Check that it points to Paseo testnet.
 ** Go to `Network` > `Parachains`.

--- a/docs/modules/ROOT/pages/guides/testing_with_zombienet.adoc
+++ b/docs/modules/ROOT/pages/guides/testing_with_zombienet.adoc
@@ -7,7 +7,7 @@
 In this tutorial, we will demonstrate how to deploy your parachain using Zombienet, and test the functionalities of your parachain.
 
 Below are the main steps of this demo:
-. Deploy our parachain against the locally simulated rococo testnet by Zombienet.
+. Deploy our parachain against the locally simulated Paseo testnet by Zombienet.
 . Deploy a Solidity smart contract on our parachain.
 . Successfully invoke the Solidity smart contract deployed on our parachain.
 
@@ -25,7 +25,7 @@ cd evm-template
 +
 ```rust
 [relaychain]
-chain = "rococo-local"
+chain = "paseo-local"
 default_command = "./bin-v1.6.0/polkadot"
 
 [[relaychain.nodes]]
@@ -162,7 +162,7 @@ image::zombie-chain-spec.png[Zombie Chain Spec]
     --rpc-port 8844 \
     -- \
     --execution wasm \
-    --chain /var/folders/...{redacted}.../rococo-local.json \
+    --chain /var/folders/...{redacted}.../paseo-local.json \
     --port 30343 \
     --rpc-port 9977
 ```

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -3,7 +3,7 @@
 
 = Polkadot Parachain Runtimes
 
-A collection of runtimes that describe parachains with different purposes.
+A collection of secure runtime templates to build parachains more easily on Polkadot.
 
 == Runtimes
 * xref:runtimes/generic.adoc[Generic Runtime Template]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -10,7 +10,7 @@ A collection of secure runtime templates to build parachains more easily on Polk
 * xref:runtimes/evm.adoc[EVM Runtime Template]
 
 
-== A Couple of Good Starting Places
+== Where to get started
 * xref:guides/quick_start.adoc[Quick Start]: a generic parachain runtime that works out of the box. It has all the must have features, and allows further customization based on your project's needs. Generic Runtime Template also serves as the base for our other runtime templates.
 * xref:guides/testing_with_zombienet.adoc[Testing with Zombienet]: a more opinionated parachain runtime template that maximizes Ethereum compatibility by using `AccountId20` and configures a local EVM instance. You can easily migrate/deploy Solidity Smart Contracts to this one.
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -5,12 +5,12 @@
 
 A collection of runtimes that describe parachains with different purposes.
 
-=== Runtimes
-* xref:guides/runtimes/generic.adoc[Generic Runtime Template]
+== Runtimes
+* xref:runtimes/generic.adoc[Generic Runtime Template]
 * xref:runtimes/evm.adoc[EVM Runtime Template]
 
 
-=== A Couple of Good Starting Places
+== A Couple of Good Starting Places
 * xref:guides/quick_start.adoc[Quick Start]: a generic parachain runtime that works out of the box. It has all the must have features, and allows further customization based on your project's needs. Generic Runtime Template also serves as the base for our other runtime templates.
 * xref:guides/testing_with_zombienet.adoc[Testing with Zombienet]: a more opinionated parachain runtime template that maximizes Ethereum compatibility by using `AccountId20` and configures a local EVM instance. You can easily migrate/deploy Solidity Smart Contracts to this one.
 

--- a/docs/modules/ROOT/pages/runtimes/evm.adoc
+++ b/docs/modules/ROOT/pages/runtimes/evm.adoc
@@ -1,11 +1,11 @@
 :source-highlighter: highlight.js
 :highlightjs-languages: rust
 :github-icon: pass:[<svg class="icon"><use href="#github-icon"/></svg>]
-= Generic Runtime
+= EVM Runtime
 
 == Purpose
 
-EVM Runtime Template is built on top of the link:generic.adoc[Generic Runtime Template].
+EVM Runtime Template is built on top of the xref:runtimes/generic.adoc[Generic Runtime Template].
 
 The purpose of this template is to provide EVM compatibilities embedded into the runtime.
 

--- a/evm-template/Cargo.lock
+++ b/evm-template/Cargo.lock
@@ -9403,7 +9403,6 @@ version = "7.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-v1.10.0#7049c3c98836b3e9253f6aaa69b6bf3d622e3962"
 dependencies = [
  "async-trait",
- "bitvec",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "frame-support",
@@ -9459,7 +9458,6 @@ dependencies = [
  "polkadot-runtime-parachains",
  "polkadot-statement-distribution",
  "rococo-runtime",
- "rococo-runtime-constants",
  "sc-authority-discovery",
  "sc-basic-authorship",
  "sc-block-builder",

--- a/evm-template/Cargo.toml
+++ b/evm-template/Cargo.toml
@@ -98,10 +98,7 @@ substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", t
 
 # Polkadot
 pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, tag = "polkadot-v1.10.0" }
-#TODO: there's no paseo-native flag(https://github.com/paritytech/polkadot-sdk/blob/master/polkadot/cli/Cargo.toml)
-polkadot-cli = { git = "https://github.com/paritytech/polkadot-sdk", features = [
-	"rococo-native",
-], tag = "polkadot-v1.10.0" }
+polkadot-cli = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-v1.10.0" }
 polkadot-parachain-primitives = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, tag = "polkadot-v1.10.0" }
 polkadot-primitives = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, tag = "polkadot-v1.10.0" }
 polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, tag = "polkadot-v1.10.0" }

--- a/evm-template/Cargo.toml
+++ b/evm-template/Cargo.toml
@@ -98,6 +98,7 @@ substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", t
 
 # Polkadot
 pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, tag = "polkadot-v1.10.0" }
+#TODO: there's no paseo-native flag(https://github.com/paritytech/polkadot-sdk/blob/master/polkadot/cli/Cargo.toml)
 polkadot-cli = { git = "https://github.com/paritytech/polkadot-sdk", features = [
 	"rococo-native",
 ], tag = "polkadot-v1.10.0" }

--- a/evm-template/node/Cargo.toml
+++ b/evm-template/node/Cargo.toml
@@ -59,8 +59,7 @@ substrate-frame-rpc-system = { workspace = true }
 substrate-prometheus-endpoint = { workspace = true }
 
 # Polkadot
-#TODO: there's no paseo-native flag(https://github.com/paritytech/polkadot-sdk/blob/master/polkadot/cli/Cargo.toml)
-polkadot-cli = { workspace = true, features = [ "rococo-native" ] }
+polkadot-cli = { workspace = true }
 polkadot-primitives = { workspace = true }
 xcm = { workspace = true }
 

--- a/evm-template/node/Cargo.toml
+++ b/evm-template/node/Cargo.toml
@@ -59,6 +59,7 @@ substrate-frame-rpc-system = { workspace = true }
 substrate-prometheus-endpoint = { workspace = true }
 
 # Polkadot
+#TODO: there's no paseo-native flag(https://github.com/paritytech/polkadot-sdk/blob/master/polkadot/cli/Cargo.toml)
 polkadot-cli = { workspace = true, features = [ "rococo-native" ] }
 polkadot-primitives = { workspace = true }
 xcm = { workspace = true }

--- a/evm-template/node/src/chain_spec.rs
+++ b/evm-template/node/src/chain_spec.rs
@@ -84,7 +84,7 @@ pub fn development_config(contracts_path: ContractsPath) -> ChainSpec {
     ChainSpec::builder(
         evm_runtime_template::WASM_BINARY.expect("WASM binary was not built, please build it!"),
         Extensions {
-            relay_chain: "rococo-local".into(),
+            relay_chain: "paseo-local".into(),
             // You MUST set this to the correct network!
             para_id: 1000,
         },
@@ -135,7 +135,7 @@ pub fn local_testnet_config(contracts_path: ContractsPath) -> ChainSpec {
     ChainSpec::builder(
         evm_runtime_template::WASM_BINARY.expect("WASM binary was not built, please build it!"),
         Extensions {
-            relay_chain: "rococo-local".into(),
+            relay_chain: "paseo-local".into(),
             // You MUST set this to the correct network!
             para_id: 1000,
         },

--- a/evm-template/node/src/cli.rs
+++ b/evm-template/node/src/cli.rs
@@ -96,12 +96,12 @@ const AFTER_HELP_EXAMPLE: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</></>
    <bold>parachain-template-node build-spec --disable-default-bootnode > plain-parachain-chainspec.json</>
            Export a chainspec for a local testnet in json format.
-   <bold>parachain-template-node --chain plain-parachain-chainspec.json --tmp -- --chain rococo-local</>
+   <bold>parachain-template-node --chain plain-parachain-chainspec.json --tmp -- --chain paseo-local</>
            Launch a full node with chain specification loaded from plain-parachain-chainspec.json.
    <bold>parachain-template-node</>
-           Launch a full node with default parachain <italic>local-testnet</> and relay chain <italic>rococo-local</>.
+           Launch a full node with default parachain <italic>local-testnet</> and relay chain <italic>paseo-local</>.
    <bold>parachain-template-node --collator</>
-           Launch a collator with default parachain <italic>local-testnet</> and relay chain <italic>rococo-local</>.
+           Launch a collator with default parachain <italic>local-testnet</> and relay chain <italic>paseo-local</>.
  "#
 );
 #[derive(Debug, clap::Parser)]

--- a/evm-template/node/src/command.rs
+++ b/evm-template/node/src/command.rs
@@ -25,7 +25,7 @@ fn load_spec(
 ) -> std::result::Result<Box<dyn ChainSpec>, String> {
     Ok(match id {
         "dev" => Box::new(chain_spec::development_config(contracts_path)),
-        "template-rococo" => Box::new(chain_spec::local_testnet_config(contracts_path)),
+        "template-paseo" => Box::new(chain_spec::local_testnet_config(contracts_path)),
         "" | "local" => Box::new(chain_spec::local_testnet_config(contracts_path)),
         path => Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?),
     })

--- a/evm-template/polkadot-launch/config.json
+++ b/evm-template/polkadot-launch/config.json
@@ -1,7 +1,7 @@
 {
 	"relaychain": {
 		"bin": "../../polkadot/target/release/polkadot",
-		"chain": "rococo-local",
+		"chain": "paseo-local",
 		"nodes": [
 			{
 				"name": "alice",

--- a/evm-template/runtime/src/lib.rs
+++ b/evm-template/runtime/src/lib.rs
@@ -119,7 +119,7 @@ impl WeightToFeePolynomial for WeightToFee {
     type Balance = Balance;
 
     fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-        // in Rococo, extrinsic base weight (smallest non-zero weight) is mapped to 1
+        // in Paseo, extrinsic base weight (smallest non-zero weight) is mapped to 1
         // MILLIUNIT: in our template, we map to 1/10 of that, or 1/10 MILLIUNIT
         let p = MILLICENTS / P_FACTOR;
         let q = Q_FACTOR * Balance::from(ExtrinsicBaseWeight::get().ref_time());

--- a/evm-template/scripts/zombienet.sh
+++ b/evm-template/scripts/zombienet.sh
@@ -92,7 +92,7 @@ zombienet_build() {
 zombienet_devnet() {
   zombienet_init
   cargo build --release
-  echo "spawning rococo-local relay chain plus devnet as a parachain..."
+  echo "spawning paseo-local relay chain plus devnet as a parachain..."
   local dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
   ./$ZOMBIENET_BIN spawn "$dir/../zombienet-config/devnet.toml" -p native
 }
@@ -103,7 +103,7 @@ print_help() {
   echo ""
   echo "$ ./zombienet.sh init         # fetches zombienet and polkadot executables"
   echo "$ ./zombienet.sh build        # builds polkadot executables from source"
-  echo "$ ./zombienet.sh devnet       # spawns a rococo-local relay chain plus parachain devnet-local as a parachain"
+  echo "$ ./zombienet.sh devnet       # spawns a paseo-local relay chain plus parachain devnet-local as a parachain"
 }
 
 SUBCOMMAND=$1

--- a/evm-template/zombienet-config/devnet.toml
+++ b/evm-template/zombienet-config/devnet.toml
@@ -1,5 +1,5 @@
 [relaychain]
-chain = "rococo-local"
+chain = "paseo-local"
 default_command = "./bin-v1.6.0/polkadot"
 
 [[relaychain.nodes]]

--- a/generic-template/Cargo.lock
+++ b/generic-template/Cargo.lock
@@ -8624,7 +8624,6 @@ version = "7.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-v1.10.0#7049c3c98836b3e9253f6aaa69b6bf3d622e3962"
 dependencies = [
  "async-trait",
- "bitvec",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "frame-support",
@@ -8680,7 +8679,6 @@ dependencies = [
  "polkadot-runtime-parachains",
  "polkadot-statement-distribution",
  "rococo-runtime",
- "rococo-runtime-constants",
  "sc-authority-discovery",
  "sc-basic-authorship",
  "sc-block-builder",

--- a/generic-template/Cargo.toml
+++ b/generic-template/Cargo.toml
@@ -95,9 +95,7 @@ substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", t
 
 # Polkadot
 pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, tag = "polkadot-v1.10.0" }
-polkadot-cli = { git = "https://github.com/paritytech/polkadot-sdk", features = [
-	"rococo-native",
-], tag = "polkadot-v1.10.0" }
+polkadot-cli = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-v1.10.0" }
 polkadot-parachain-primitives = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, tag = "polkadot-v1.10.0" }
 polkadot-primitives = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, tag = "polkadot-v1.10.0" }
 polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, tag = "polkadot-v1.10.0" }

--- a/generic-template/node/Cargo.toml
+++ b/generic-template/node/Cargo.toml
@@ -54,7 +54,7 @@ substrate-frame-rpc-system = { workspace = true }
 substrate-prometheus-endpoint = { workspace = true }
 
 # Polkadot
-polkadot-cli = { workspace = true, features = [ "rococo-native" ] }
+polkadot-cli = { workspace = true }
 polkadot-primitives = { workspace = true }
 xcm = { workspace = true }
 

--- a/generic-template/node/src/chain_spec.rs
+++ b/generic-template/node/src/chain_spec.rs
@@ -77,7 +77,7 @@ pub fn development_config() -> ChainSpec {
     ChainSpec::builder(
         generic_runtime_template::WASM_BINARY.expect("WASM binary was not built, please build it!"),
         Extensions {
-            relay_chain: "rococo-local".into(),
+            relay_chain: "paseo-local".into(),
             // You MUST set this to the correct network!
             para_id: 1000,
         },
@@ -128,7 +128,7 @@ pub fn local_testnet_config() -> ChainSpec {
     ChainSpec::builder(
         generic_runtime_template::WASM_BINARY.expect("WASM binary was not built, please build it!"),
         Extensions {
-            relay_chain: "rococo-local".into(),
+            relay_chain: "paseo-local".into(),
             // You MUST set this to the correct network!
             para_id: 1000,
         },

--- a/generic-template/node/src/cli.rs
+++ b/generic-template/node/src/cli.rs
@@ -49,12 +49,12 @@ const AFTER_HELP_EXAMPLE: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</></>
    <bold>parachain-template-node build-spec --disable-default-bootnode > plain-parachain-chainspec.json</>
            Export a chainspec for a local testnet in json format.
-   <bold>parachain-template-node --chain plain-parachain-chainspec.json --tmp -- --chain rococo-local</>
+   <bold>parachain-template-node --chain plain-parachain-chainspec.json --tmp -- --chain paseo-local</>
            Launch a full node with chain specification loaded from plain-parachain-chainspec.json.
    <bold>parachain-template-node</>
-           Launch a full node with default parachain <italic>local-testnet</> and relay chain <italic>rococo-local</>.
+           Launch a full node with default parachain <italic>local-testnet</> and relay chain <italic>paseo-local</>.
    <bold>parachain-template-node --collator</>
-           Launch a collator with default parachain <italic>local-testnet</> and relay chain <italic>rococo-local</>.
+           Launch a collator with default parachain <italic>local-testnet</> and relay chain <italic>paseo-local</>.
  "#
 );
 #[derive(Debug, clap::Parser)]

--- a/generic-template/node/src/command.rs
+++ b/generic-template/node/src/command.rs
@@ -21,7 +21,7 @@ use crate::{
 fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
     Ok(match id {
         "dev" => Box::new(chain_spec::development_config()),
-        "template-rococo" => Box::new(chain_spec::local_testnet_config()),
+        "template-paseo" => Box::new(chain_spec::local_testnet_config()),
         "" | "local" => Box::new(chain_spec::local_testnet_config()),
         path => Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?),
     })

--- a/generic-template/runtime/src/lib.rs
+++ b/generic-template/runtime/src/lib.rs
@@ -56,7 +56,7 @@ impl WeightToFeePolynomial for WeightToFee {
     type Balance = Balance;
 
     fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-        // in Rococo, extrinsic base weight (smallest non-zero weight) is mapped to 1
+        // in Paseo, extrinsic base weight (smallest non-zero weight) is mapped to 1
         // MILLIUNIT: in our template, we map to 1/10 of that, or 1/10 MILLIUNIT
         let p = MILLICENTS / P_FACTOR;
         let q = Q_FACTOR * Balance::from(ExtrinsicBaseWeight::get().ref_time());

--- a/generic-template/scripts/zombienet.sh
+++ b/generic-template/scripts/zombienet.sh
@@ -92,7 +92,7 @@ zombienet_build() {
 zombienet_devnet() {
   zombienet_init
   cargo build --release
-  echo "spawning rococo-local relay chain plus devnet as a parachain..."
+  echo "spawning paseo-local relay chain plus devnet as a parachain..."
   local dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
   ./$ZOMBIENET_BIN spawn "$dir/../zombienet-config/devnet.toml" -p native
 }
@@ -103,7 +103,7 @@ print_help() {
   echo ""
   echo "$ ./zombienet.sh init         # fetches zombienet and polkadot executables"
   echo "$ ./zombienet.sh build        # builds polkadot executables from source"
-  echo "$ ./zombienet.sh devnet       # spawns a rococo-local relay chain plus parachain devnet-local as a parachain"
+  echo "$ ./zombienet.sh devnet       # spawns a paseo-local relay chain plus parachain devnet-local as a parachain"
 }
 
 SUBCOMMAND=$1

--- a/generic-template/zombienet-config/devnet.toml
+++ b/generic-template/zombienet-config/devnet.toml
@@ -1,5 +1,5 @@
 [relaychain]
-chain = "rococo-local"
+chain = "paseo-local"
 default_command = "./bin-v1.6.0/polkadot"
 
 [[relaychain.nodes]]


### PR DESCRIPTION
Fixes #318 

- Migrate all references from rococo to paseo(both in docs and chainspec, code, etc).
- Slightly improve docs and fix some broken links


- [x] Documentation
