### PR TITLE
roll back to rococo local for now

### DIFF
--- a/docs/modules/ROOT/pages/guides/quick_start.adoc
+++ b/docs/modules/ROOT/pages/guides/quick_start.adoc
@@ -46,7 +46,7 @@ We use the `generic-template-node` executable throughout all the commands since 
 ** Edit the chainspec:
 
 *** Update `name`, `id` and `protocolId` to unique values.
-*** Change `relay_chain` from `paseo-local` to `paseo`.
+*** Change `relay_chain` from `rococo-local` to `paseo`.
 *** Change `para_id` and `parachainInfo.parachainId` from `1000` to the previously saved parachain id.
 
 ** Generate a raw chainspec with this command:

--- a/docs/modules/ROOT/pages/guides/testing_with_zombienet.adoc
+++ b/docs/modules/ROOT/pages/guides/testing_with_zombienet.adoc
@@ -25,7 +25,7 @@ cd evm-template
 +
 ```rust
 [relaychain]
-chain = "paseo-local"
+chain = "rococo-local"
 default_command = "./bin-v1.6.0/polkadot"
 
 [[relaychain.nodes]]
@@ -162,7 +162,7 @@ image::zombie-chain-spec.png[Zombie Chain Spec]
     --rpc-port 8844 \
     -- \
     --execution wasm \
-    --chain /var/folders/...{redacted}.../paseo-local.json \
+    --chain /var/folders/...{redacted}.../rococo-local.json \
     --port 30343 \
     --rpc-port 9977
 ```

--- a/evm-template/node/src/chain_spec.rs
+++ b/evm-template/node/src/chain_spec.rs
@@ -85,7 +85,7 @@ pub fn development_config(contracts_path: ContractsPath) -> ChainSpec {
     ChainSpec::builder(
         evm_runtime_template::WASM_BINARY.expect("WASM binary was not built, please build it!"),
         Extensions {
-            relay_chain: "paseo-local".into(),
+            relay_chain: "rococo-local".into(),
             // You MUST set this to the correct network!
             para_id: 1000,
         },
@@ -131,7 +131,7 @@ pub fn local_testnet_config(contracts_path: ContractsPath) -> ChainSpec {
     ChainSpec::builder(
         evm_runtime_template::WASM_BINARY.expect("WASM binary was not built, please build it!"),
         Extensions {
-            relay_chain: "paseo-local".into(),
+            relay_chain: "rococo-local".into(),
             // You MUST set this to the correct network!
             para_id: 1000,
         },

--- a/evm-template/node/src/cli.rs
+++ b/evm-template/node/src/cli.rs
@@ -96,12 +96,12 @@ const AFTER_HELP_EXAMPLE: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</></>
    <bold>parachain-template-node build-spec --disable-default-bootnode > plain-parachain-chainspec.json</>
            Export a chainspec for a local testnet in json format.
-   <bold>parachain-template-node --chain plain-parachain-chainspec.json --tmp -- --chain paseo-local</>
+   <bold>parachain-template-node --chain plain-parachain-chainspec.json --tmp -- --chain rococo-local</>
            Launch a full node with chain specification loaded from plain-parachain-chainspec.json.
    <bold>parachain-template-node</>
-           Launch a full node with default parachain <italic>local-testnet</> and relay chain <italic>paseo-local</>.
+           Launch a full node with default parachain <italic>local-testnet</> and relay chain <italic>rococo-local</>.
    <bold>parachain-template-node --collator</>
-           Launch a collator with default parachain <italic>local-testnet</> and relay chain <italic>paseo-local</>.
+           Launch a collator with default parachain <italic>local-testnet</> and relay chain <italic>rococo-local</>.
  "#
 );
 #[derive(Debug, clap::Parser)]

--- a/evm-template/polkadot-launch/config.json
+++ b/evm-template/polkadot-launch/config.json
@@ -1,7 +1,7 @@
 {
 	"relaychain": {
 		"bin": "../../polkadot/target/release/polkadot",
-		"chain": "paseo-local",
+		"chain": "rococo-local",
 		"nodes": [
 			{
 				"name": "alice",
@@ -34,6 +34,5 @@
 			]
 		}
 	],
-	"types": {
-	}
+	"types": {}
 }

--- a/evm-template/scripts/zombienet.sh
+++ b/evm-template/scripts/zombienet.sh
@@ -77,7 +77,7 @@ zombienet_build() {
 zombienet_devnet() {
   zombienet_init
   cargo build --release
-  echo "spawning paseo-local relay chain plus devnet as a parachain..."
+  echo "spawning rococo-local relay chain plus devnet as a parachain..."
   local dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
   ./$ZOMBIENET_BIN spawn "$dir/../zombienet-config/devnet.toml" -p native
 }
@@ -88,7 +88,7 @@ print_help() {
   echo ""
   echo "$ ./zombienet.sh init         # fetches zombienet and polkadot executables"
   echo "$ ./zombienet.sh build        # builds polkadot executables from source"
-  echo "$ ./zombienet.sh devnet       # spawns a paseo-local relay chain plus parachain devnet-local as a parachain"
+  echo "$ ./zombienet.sh devnet       # spawns a rococo-local relay chain plus parachain devnet-local as a parachain"
 }
 
 SUBCOMMAND=$1

--- a/evm-template/zombienet-config/devnet.toml
+++ b/evm-template/zombienet-config/devnet.toml
@@ -1,5 +1,5 @@
 [relaychain]
-chain = "paseo-local"
+chain = "rococo-local"
 default_command = "./bin-stable2407-1/polkadot"
 
 [[relaychain.nodes]]

--- a/generic-template/node/src/chain_spec.rs
+++ b/generic-template/node/src/chain_spec.rs
@@ -77,7 +77,7 @@ pub fn development_config() -> ChainSpec {
     ChainSpec::builder(
         generic_runtime_template::WASM_BINARY.expect("WASM binary was not built, please build it!"),
         Extensions {
-            relay_chain: "paseo-local".into(),
+            relay_chain: "rococo-local".into(),
             // You MUST set this to the correct network!
             para_id: 1000,
         },
@@ -128,7 +128,7 @@ pub fn local_testnet_config() -> ChainSpec {
     ChainSpec::builder(
         generic_runtime_template::WASM_BINARY.expect("WASM binary was not built, please build it!"),
         Extensions {
-            relay_chain: "paseo-local".into(),
+            relay_chain: "rococo-local".into(),
             // You MUST set this to the correct network!
             para_id: 1000,
         },

--- a/generic-template/node/src/cli.rs
+++ b/generic-template/node/src/cli.rs
@@ -49,12 +49,12 @@ const AFTER_HELP_EXAMPLE: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</></>
    <bold>parachain-template-node build-spec --disable-default-bootnode > plain-parachain-chainspec.json</>
            Export a chainspec for a local testnet in json format.
-   <bold>parachain-template-node --chain plain-parachain-chainspec.json --tmp -- --chain paseo-local</>
+   <bold>parachain-template-node --chain plain-parachain-chainspec.json --tmp -- --chain rococo-local</>
            Launch a full node with chain specification loaded from plain-parachain-chainspec.json.
    <bold>parachain-template-node</>
-           Launch a full node with default parachain <italic>local-testnet</> and relay chain <italic>paseo-local</>.
+           Launch a full node with default parachain <italic>local-testnet</> and relay chain <italic>rococo-local</>.
    <bold>parachain-template-node --collator</>
-           Launch a collator with default parachain <italic>local-testnet</> and relay chain <italic>paseo-local</>.
+           Launch a collator with default parachain <italic>local-testnet</> and relay chain <italic>rococo-local</>.
  "#
 );
 #[derive(Debug, clap::Parser)]

--- a/generic-template/scripts/zombienet.sh
+++ b/generic-template/scripts/zombienet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ZOMBIENET_V=v1.3.106
-POLKADOT_V=stable-2407-01
+POLKADOT_V=stable2407-1
 
 # Detect the operating system
 case "$(uname -s)" in
@@ -45,7 +45,7 @@ build_polkadot() {
   pushd /tmp
     git clone https://github.com/paritytech/polkadot-sdk.git
     pushd polkadot-sdk
-      git checkout release-polkadot-$POLKADOT_V
+      git checkout polkadot-$POLKADOT_V
       echo "building polkadot executable..."
       cargo build --release --features fast-runtime
       cp target/release/polkadot "$CWD/$BIN_DIR"
@@ -55,26 +55,11 @@ build_polkadot() {
   popd
 }
 
-fetch_polkadot() {
-  echo "fetching from polkadot repository..."
-  echo $BIN_DIR
-  mkdir -p "$BIN_DIR"
-  pushd "$BIN_DIR"
-    wget https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-$POLKADOT_V/polkadot
-    wget https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-$POLKADOT_V/polkadot-execute-worker
-    wget https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-$POLKADOT_V/polkadot-prepare-worker
-    chmod +x *
-  popd
-}
-
 zombienet_init() {
   if [ ! -f $ZOMBIENET_BIN ]; then
     echo "fetching zombienet executable..."
     curl -LO https://github.com/paritytech/zombienet/releases/download/$ZOMBIENET_V/$ZOMBIENET_BIN
     chmod +x $ZOMBIENET_BIN
-  fi
-  if [ ! -f $BIN_DIR/polkadot ]; then
-    fetch_polkadot
   fi
 }
 
@@ -92,7 +77,7 @@ zombienet_build() {
 zombienet_devnet() {
   zombienet_init
   cargo build --release
-  echo "spawning paseo-local relay chain plus devnet as a parachain..."
+  echo "spawning rococo-local relay chain plus devnet as a parachain..."
   local dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
   ./$ZOMBIENET_BIN spawn "$dir/../zombienet-config/devnet.toml" -p native
 }
@@ -103,7 +88,7 @@ print_help() {
   echo ""
   echo "$ ./zombienet.sh init         # fetches zombienet and polkadot executables"
   echo "$ ./zombienet.sh build        # builds polkadot executables from source"
-  echo "$ ./zombienet.sh devnet       # spawns a paseo-local relay chain plus parachain devnet-local as a parachain"
+  echo "$ ./zombienet.sh devnet       # spawns a rococo-local relay chain plus parachain devnet-local as a parachain"
 }
 
 SUBCOMMAND=$1

--- a/generic-template/zombienet-config/devnet.toml
+++ b/generic-template/zombienet-config/devnet.toml
@@ -1,6 +1,6 @@
 [relaychain]
-chain = "paseo-local"
-default_command = "./bin-v1.6.0/polkadot"
+chain = "rococo-local"
+default_command = "./bin-stable2407-1/polkadot"
 
 [[relaychain.nodes]]
 name = "alice"


### PR DESCRIPTION
Fixes #352 

Currently polkadot-sdk does not support `paseo-local` option for the CLI arguments. 

We will use `rococo-local` till `paseo-local` option is implemented.
