### PR TITLE
Fix missing protoc in fuzzing run

### DIFF
--- a/.github/workflows/evm-weekly-fuzzer.yml
+++ b/.github/workflows/evm-weekly-fuzzer.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install Protocol Buffers Compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/generic-weekly-fuzzer.yml
+++ b/.github/workflows/generic-weekly-fuzzer.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install Protocol Buffers Compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -31,7 +36,7 @@ jobs:
 
       - name: Run Ziggy Fuzzing
         run: |
-          AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 timeout 5h cargo ziggy fuzz -t 20 || true
+          AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 timeout 5m cargo ziggy fuzz -t 20 || true
         working-directory: generic-template/template-fuzzer
 
       - name: Generate Ziggy Fuzzing Coverage Result

--- a/.github/workflows/generic-weekly-fuzzer.yml
+++ b/.github/workflows/generic-weekly-fuzzer.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Ziggy Fuzzing
         run: |
-          AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 timeout 5m cargo ziggy fuzz -t 20 || true
+          AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 timeout 5h cargo ziggy fuzz -t 20 || true
         working-directory: generic-template/template-fuzzer
 
       - name: Generate Ziggy Fuzzing Coverage Result


### PR DESCRIPTION
Missing protobuf compiler failed the fuzzing run coverage generation.
There was a successful run with these changes: https://github.com/OpenZeppelin/polkadot-runtime-templates/actions/runs/13071431290

