### PR TITLE
fix: set `with_properties` in generic-template

### DIFF
--- a/generic-template/node/src/chain_spec.rs
+++ b/generic-template/node/src/chain_spec.rs
@@ -117,6 +117,7 @@ pub fn development_config() -> ChainSpec {
         get_account_id_from_seed::<sr25519::Public>("Alice"),
         1000.into(),
     ))
+    .with_properties(properties)
     .build()
 }
 


### PR DESCRIPTION
I saw that your templates use the `basedOn` [property](https://github.com/OpenZeppelin/polkadot-runtime-templates/blob/main/evm-template/node/src/chain_spec.rs#L90), which will be very useful for a new feature we're developing in [pop-cli](https://github.com/r0gue-io/pop-cli) to identify the template in use. 

However, I noticed that the `generic-templates` are missing this property in the development chain spec config, whereas it's correctly set in the evm-template (https://github.com/OpenZeppelin/polkadot-runtime-templates/blob/main/evm-template/node/src/chain_spec.rs#L126).
This simple PR fixes that.